### PR TITLE
ci(sync): check upstream releases hourly

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,9 +1,9 @@
 name: Sync with Upstream Release
 
 on:
-  # Check for new upstream releases daily
+  # Check for new upstream releases hourly
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       upstream_tag:


### PR DESCRIPTION
## Summary
- Change upstream release check from daily (6 AM UTC) to hourly
- Build still only triggers when there's actually a new upstream release
- More responsive to upstream security patches

## Test plan
- [ ] Verify workflow runs hourly
- [ ] Confirm no unnecessary builds when no new release