### PR TITLE
fix(rpm): use explicit file paths in spec for Fedora 39/40/41 compatibility

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -657,11 +657,11 @@ jobs:
           VERSION="${{ needs.prepare.outputs.version }}"
           UPSTREAM="${{ needs.prepare.outputs.upstream_version }}"
 
-          # Create release notes
+          # Create release notes (using {{PLACEHOLDER}} pattern for clarity)
           cat > release-notes.md << 'EOF'
-          ## strongSwan SW $VERSION
+          ## strongSwan SW {{VERSION}}
 
-          This release is based on upstream strongSwan $UPSTREAM with SW fork modifications.
+          This release is based on upstream strongSwan {{UPSTREAM}} with SW fork modifications.
 
           ### Installation
 
@@ -695,12 +695,20 @@ jobs:
           For full changelog, see the [sw branch](https://github.com/structured-world/strongswan/tree/sw).
           EOF
 
-          # Substitute variables in release notes
-          sed -i "s/\$VERSION/${VERSION}/g" release-notes.md
-          sed -i "s/\$UPSTREAM/${UPSTREAM}/g" release-notes.md
+          # Substitute placeholders in release notes
+          sed -i "s/{{VERSION}}/${VERSION}/g" release-notes.md
+          sed -i "s/{{UPSTREAM}}/${UPSTREAM}/g" release-notes.md
 
-          # Create tag and release
-          gh release create "${VERSION}" \
-            --title "strongSwan SW ${VERSION}" \
-            --notes-file release-notes.md \
-            --target sw
+          # Create or update GitHub release (idempotent)
+          if gh release view "${VERSION}" >/dev/null 2>&1; then
+            echo "Release ${VERSION} exists, updating..."
+            gh release edit "${VERSION}" \
+              --title "strongSwan SW ${VERSION}" \
+              --notes-file release-notes.md
+          else
+            echo "Creating release ${VERSION}..."
+            gh release create "${VERSION}" \
+              --title "strongSwan SW ${VERSION}" \
+              --notes-file release-notes.md \
+              --target sw
+          fi

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -638,3 +638,69 @@ jobs:
             git push
             echo "Pushed release ${VERSION} to repository"
           fi
+
+  # Create GitHub Release in the fork (no artifacts, just links to package repo)
+  release:
+    needs: [prepare, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          UPSTREAM="${{ needs.prepare.outputs.upstream_version }}"
+
+          # Create release notes
+          cat > release-notes.md << 'EOF'
+          ## strongSwan SW $VERSION
+
+          This release is based on upstream strongSwan $UPSTREAM with SW fork modifications.
+
+          ### Installation
+
+          Packages are available from the [strongswan-sw-repo](https://github.com/structured-world/strongswan-sw-repo).
+
+          **Fedora/RHEL:**
+          ```bash
+          # Add repository (one-time setup)
+          sudo dnf config-manager --add-repo https://structured-world.github.io/strongswan-sw-repo/rpm/fedora/\$releasever/strongswan-sw.repo
+
+          # Install
+          sudo dnf install strongswan-sw
+          ```
+
+          **Ubuntu/Debian:**
+          ```bash
+          # Add repository (one-time setup)
+          curl -fsSL https://structured-world.github.io/strongswan-sw-repo/deb/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/strongswan-sw.gpg
+          echo "deb [signed-by=/usr/share/keyrings/strongswan-sw.gpg] https://structured-world.github.io/strongswan-sw-repo/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/strongswan-sw.list
+
+          # Install
+          sudo apt update && sudo apt install strongswan-sw
+          ```
+
+          ### SW Fork Changes
+
+          - PostgreSQL database plugin for SQL authentication
+          - Unix socket permissions fix (umask 0660)
+          - DHCP-inform plugin for Windows split-tunnel routes
+
+          For full changelog, see the [sw branch](https://github.com/structured-world/strongswan/tree/sw).
+          EOF
+
+          # Substitute variables in release notes
+          sed -i "s/\$VERSION/${VERSION}/g" release-notes.md
+          sed -i "s/\$UPSTREAM/${UPSTREAM}/g" release-notes.md
+
+          # Create tag and release
+          gh release create "${VERSION}" \
+            --title "strongSwan SW ${VERSION}" \
+            --notes-file release-notes.md \
+            --target sw

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -477,7 +477,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
         with:
-          repository: structured-world/repo
+          repository: structured-world/strongswan-sw-repo
           token: ${{ secrets.REPO_TOKEN }}
           path: repo
 
@@ -670,7 +670,7 @@ jobs:
           **Fedora/RHEL:**
           ```bash
           # Add repository (one-time setup)
-          sudo dnf config-manager --add-repo https://structured-world.github.io/strongswan-sw-repo/rpm/fedora/\$releasever/strongswan-sw.repo
+          sudo dnf config-manager --add-repo https://structured-world.github.io/strongswan-sw-repo/rpm/fc\$releasever/strongswan-sw.repo
 
           # Install
           sudo dnf install strongswan-sw

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -101,11 +101,15 @@ jobs:
 
       - name: Setup git for tarball creation
         run: |
-          # Configure git for tarball creation (actions/checkout@v4 handles .git)
+          # In container environments, actions/checkout may not create .git properly
+          # due to filesystem boundaries. Initialize if missing for git archive to work.
           git config --global init.defaultBranch main
           git config --global user.email "test@example.com"
           git config --global user.name "Test"
           git config --global --add safe.directory "$(pwd)"
+          if [ ! -d .git ]; then
+            git init && git add -A && git commit -m "test"
+          fi
 
       - name: Build RPM with spec file
         run: |

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -95,48 +95,47 @@ jobs:
             iptables-devel \
             gperf \
             flex \
-            bison
+            bison \
+            rpm-build \
+            rpmdevtools
 
-      - name: Run autoreconf
-        run: autoreconf -fiv
-
-      - name: Configure
+      - name: Setup git for tarball creation
         run: |
-          ./configure --disable-static \
-            --prefix=/usr \
-            --sysconfdir=/etc \
-            --enable-eap-identity \
-            --enable-eap-mschapv2 \
-            --enable-eap-radius \
-            --enable-eap-tls \
-            --enable-xauth-eap \
-            --enable-vici \
-            --enable-swanctl \
-            --enable-sql \
-            --enable-pgsql \
-            --enable-sqlite \
-            --enable-systemd \
-            --enable-openssl \
-            --enable-curl \
-            --enable-ldap \
-            --enable-gcrypt \
-            --enable-farp \
-            --enable-dhcp \
-            --enable-dhcp-inform \
-            --enable-attr-sql \
-            --enable-forecast \
-            --enable-pam \
-            --with-capabilities=libcap
+          git config --global init.defaultBranch main
+          git config --global user.email "test@example.com"
+          git config --global user.name "Test"
+          git config --global --add safe.directory "$(pwd)"
+          if [ ! -d .git ]; then
+            git init && git add -A && git commit -m "test"
+          fi
 
-      - name: Build
-        run: make -j$(nproc)
-
-      - name: Verify plugins built
+      - name: Build RPM with spec file
         run: |
-          echo "=== Checking SW fork plugins ==="
-          ls -la src/libstrongswan/plugins/pgsql/.libs/libstrongswan-pgsql.so
-          ls -la src/libcharon/plugins/dhcp_inform/.libs/libstrongswan-dhcp-inform.so
-          echo "All SW fork plugins built successfully"
+          # Use rpmbuild to catch hardened build errors (-Werror=format-security)
+          rpmdev-setuptree
+
+          # Get upstream version from configure.ac
+          VERSION=$(grep -m1 'AC_INIT' configure.ac | sed -E 's/.*\[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/')
+
+          # Create source tarball
+          # Note: sw_rev=1 is a placeholder for PR test builds only.
+          # Actual release versions are determined by build-packages.yml
+          SOURCE_NAME="strongswan-${VERSION}-sw.1"
+          git archive --format=tar.gz --prefix="${SOURCE_NAME}/" HEAD > ~/rpmbuild/SOURCES/${SOURCE_NAME}.tar.gz
+
+          # Build with spec file (includes hardened build flags)
+          cp packaging/rpm/strongswan-sw.spec ~/rpmbuild/SPECS/
+          rpmbuild -ba ~/rpmbuild/SPECS/strongswan-sw.spec \
+            --define "upstream_version ${VERSION}" \
+            --define "sw_rev 1" \
+            --define "_topdir $HOME/rpmbuild"
+
+      - name: Verify packages built
+        run: |
+          echo "=== Checking built RPMs ==="
+          ls -la ~/rpmbuild/RPMS/*/*.rpm
+          ls -la ~/rpmbuild/SRPMS/*.rpm
+          echo "All RPM packages built successfully"
 
   # Test build on Ubuntu (DEB)
   build-test-deb:

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -101,13 +101,11 @@ jobs:
 
       - name: Setup git for tarball creation
         run: |
+          # Configure git for tarball creation (actions/checkout@v4 handles .git)
           git config --global init.defaultBranch main
           git config --global user.email "test@example.com"
           git config --global user.name "Test"
           git config --global --add safe.directory "$(pwd)"
-          if [ ! -d .git ]; then
-            git init && git add -A && git commit -m "test"
-          fi
 
       - name: Build RPM with spec file
         run: |
@@ -116,6 +114,10 @@ jobs:
 
           # Get upstream version from configure.ac
           VERSION=$(grep -m1 'AC_INIT' configure.ac | sed -E 's/.*\[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/')
+          if [[ -z "$VERSION" || ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Invalid VERSION '$VERSION' extracted from configure.ac"
+            exit 1
+          fi
 
           # Create source tarball
           # Note: sw_rev=1 is a placeholder for PR test builds only.

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,9 +1,9 @@
 name: Sync with Upstream Release
 
 on:
-  # Check for new upstream releases hourly
+  # Check for new upstream releases daily at 6 AM UTC
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       upstream_tag:

--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -156,7 +156,6 @@ done
 %config(noreplace) %{_sysconfdir}/strongswan.d
 %{_sysconfdir}/swanctl/*
 %{_unitdir}/strongswan.service
-%{_unitdir}/strongswan-swanctl.service
 %{_sbindir}/*
 %dir %{_libdir}/ipsec
 %dir %{_libdir}/ipsec/plugins
@@ -173,13 +172,13 @@ done
 %{_libdir}/ipsec/plugins/libstrongswan-dhcp-inform.so
 
 %post
-%systemd_post strongswan.service strongswan-swanctl.service
+%systemd_post strongswan.service
 
 %preun
-%systemd_preun strongswan.service strongswan-swanctl.service
+%systemd_preun strongswan.service
 
 %postun
-%systemd_postun_with_restart strongswan.service strongswan-swanctl.service
+%systemd_postun_with_restart strongswan.service
 
 %changelog
 # Use SOURCE_DATE_EPOCH for reproducible builds if set, otherwise current date

--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -140,6 +140,7 @@ done
 %files
 %license COPYING
 %doc README NEWS
+# Configuration directories
 %dir %{_sysconfdir}/strongswan
 %dir %{_sysconfdir}/strongswan/ipsec.d
 %dir %attr(700,root,root) %{_sysconfdir}/strongswan/ipsec.d/aacerts
@@ -151,19 +152,48 @@ done
 %dir %attr(700,root,root) %{_sysconfdir}/strongswan/ipsec.d/private
 %dir %attr(700,root,root) %{_sysconfdir}/strongswan/ipsec.d/reqs
 %dir %{_sysconfdir}/swanctl
+%dir %{_sysconfdir}/swanctl/bliss
 %dir %{_sysconfdir}/swanctl/conf.d
+%dir %{_sysconfdir}/swanctl/ecdsa
+%dir %{_sysconfdir}/swanctl/pkcs8
+%dir %{_sysconfdir}/swanctl/pkcs12
+%dir %{_sysconfdir}/swanctl/private
+%dir %{_sysconfdir}/swanctl/pubkey
+%dir %{_sysconfdir}/swanctl/rsa
+%dir %{_sysconfdir}/swanctl/x509
+%dir %{_sysconfdir}/swanctl/x509aa
+%dir %{_sysconfdir}/swanctl/x509ac
+%dir %{_sysconfdir}/swanctl/x509ca
+%dir %{_sysconfdir}/swanctl/x509crl
+%dir %{_sysconfdir}/swanctl/x509ocsp
 %config(noreplace) %{_sysconfdir}/strongswan.conf
 %config(noreplace) %{_sysconfdir}/strongswan.d
-%{_sysconfdir}/swanctl/*
+%config(noreplace) %{_sysconfdir}/swanctl/swanctl.conf
+# Binaries
+%{_bindir}/pki
+%{_sbindir}/swanctl
+%{_sbindir}/charon-systemd
+# Systemd service
 %{_unitdir}/strongswan.service
-%{_sbindir}/*
+# Libraries and plugins
 %dir %{_libdir}/ipsec
 %dir %{_libdir}/ipsec/plugins
-%{_libdir}/ipsec/*
+%{_libdir}/ipsec/libcharon.so.0
+%{_libdir}/ipsec/libcharon.so.0.0.0
+%{_libdir}/ipsec/libstrongswan.so.0
+%{_libdir}/ipsec/libstrongswan.so.0.0.0
+%{_libdir}/ipsec/libvici.so.0
+%{_libdir}/ipsec/libvici.so.0.0.0
+%{_libdir}/ipsec/plugins/libstrongswan-*.so
 %exclude %{_libdir}/ipsec/plugins/libstrongswan-pgsql.so
 %exclude %{_libdir}/ipsec/plugins/libstrongswan-dhcp-inform.so
+# Data files
 %{_datadir}/strongswan
-%{_mandir}/man?/*
+# Man pages
+%{_mandir}/man1/pki*.1*
+%{_mandir}/man5/strongswan.conf.5*
+%{_mandir}/man5/swanctl.conf.5*
+%{_mandir}/man8/swanctl.8*
 
 %files -n strongswan-pgsql
 %{_libdir}/ipsec/plugins/libstrongswan-pgsql.so

--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -87,6 +87,10 @@ from PostgreSQL database. Delivers routes via DHCP option 121/249.
 %prep
 %autosetup -n strongswan-%{upstream_version}-sw.%{sw_rev}
 
+# Remove -Wno-format from upstream configure.ac to satisfy Fedora's -Werror=format-security
+# Fedora requires -Wformat to be enabled when using -Wformat-security
+sed -i '/WARN_CFLAGS=.*-Wno-format/d' configure.ac
+
 %build
 autoreconf -fiv
 
@@ -119,9 +123,7 @@ autoreconf -fiv
     --enable-pam \
     --with-capabilities=libcap
 
-# Override -Wno-format from upstream configure.ac to satisfy Fedora's -Werror=format-security
-# Pass -Wformat via make to append after configure's WARN_CFLAGS
-%make_build CFLAGS="%{build_cflags} -Wformat"
+%make_build
 
 %install
 %make_install

--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -90,10 +90,6 @@ from PostgreSQL database. Delivers routes via DHCP option 121/249.
 %build
 autoreconf -fiv
 
-# Override -Wno-format from upstream configure.ac to satisfy Fedora's -Werror=format-security
-# Must be set before %configure so it's used during both configure and make
-export CFLAGS="${CFLAGS} -Wformat"
-
 %configure --disable-static \
     --prefix=/usr \
     --sysconfdir=/etc \
@@ -123,7 +119,9 @@ export CFLAGS="${CFLAGS} -Wformat"
     --enable-pam \
     --with-capabilities=libcap
 
-%make_build
+# Override -Wno-format from upstream configure.ac to satisfy Fedora's -Werror=format-security
+# Pass -Wformat via make to append after configure's WARN_CFLAGS
+%make_build CFLAGS="%{build_cflags} -Wformat"
 
 %install
 %make_install

--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -119,6 +119,9 @@ autoreconf -fiv
     --enable-pam \
     --with-capabilities=libcap
 
+# Override -Wno-format from upstream configure.ac to satisfy Fedora's -Werror=format-security
+export CFLAGS="${CFLAGS} -Wformat"
+
 %make_build
 
 %install

--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -90,6 +90,10 @@ from PostgreSQL database. Delivers routes via DHCP option 121/249.
 %build
 autoreconf -fiv
 
+# Override -Wno-format from upstream configure.ac to satisfy Fedora's -Werror=format-security
+# Must be set before %configure so it's used during both configure and make
+export CFLAGS="${CFLAGS} -Wformat"
+
 %configure --disable-static \
     --prefix=/usr \
     --sysconfdir=/etc \
@@ -118,9 +122,6 @@ autoreconf -fiv
     --enable-forecast \
     --enable-pam \
     --with-capabilities=libcap
-
-# Override -Wno-format from upstream configure.ac to satisfy Fedora's -Werror=format-security
-export CFLAGS="${CFLAGS} -Wformat"
 
 %make_build
 

--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -87,8 +87,8 @@ from PostgreSQL database. Delivers routes via DHCP option 121/249.
 %prep
 %autosetup -n strongswan-%{upstream_version}-sw.%{sw_rev}
 
-# Remove -Wno-format from upstream configure.ac to satisfy Fedora's -Werror=format-security
-# Fedora requires -Wformat to be enabled when using -Wformat-security
+# Remove -Wno-format and -Wno-format-security from upstream configure.ac
+# Fedora's hardened build requires -Wformat to be enabled when using -Werror=format-security
 sed -i '/WARN_CFLAGS=.*-Wno-format/d' configure.ac
 
 %build
@@ -150,10 +150,11 @@ done
 %dir %attr(700,root,root) %{_sysconfdir}/strongswan/ipsec.d/ocspcerts
 %dir %attr(700,root,root) %{_sysconfdir}/strongswan/ipsec.d/private
 %dir %attr(700,root,root) %{_sysconfdir}/strongswan/ipsec.d/reqs
-%dir %{_sysconfdir}/strongswan/swanctl
-%config(noreplace) %{_sysconfdir}/strongswan/*.conf
-%config(noreplace) %{_sysconfdir}/strongswan/strongswan.d
-%{_sysconfdir}/strongswan/swanctl/*
+%dir %{_sysconfdir}/swanctl
+%dir %{_sysconfdir}/swanctl/conf.d
+%config(noreplace) %{_sysconfdir}/strongswan.conf
+%config(noreplace) %{_sysconfdir}/strongswan.d
+%{_sysconfdir}/swanctl/*
 %{_unitdir}/strongswan.service
 %{_unitdir}/strongswan-swanctl.service
 %{_sbindir}/*


### PR DESCRIPTION
## Summary
- Add `/usr/bin/pki` explicitly (was missing, causing unpackaged file error)
- List all swanctl subdirectories explicitly instead of wildcard
- List binaries explicitly: pki, swanctl, charon-systemd
- List libraries with explicit version numbers
- Keep plugin wildcard (necessary for maintainability with 50+ plugins)
- List man pages explicitly
- Remove duplicate directory entries that caused "file listed twice" errors

## Problem
Fedora 39, 40, 41 builds failed with:
```
error: Installed (but unpackaged) file(s) found:
   /usr/bin/pki
   /usr/lib/debug/usr/bin/pki-*.debug
```

Fedora 42 passed due to different default behavior for unpackaged files.

## Test plan
- [ ] Verify Fedora 39 RPM builds successfully
- [ ] Verify Fedora 40 RPM builds successfully
- [ ] Verify Fedora 41 RPM builds successfully
- [ ] Verify Fedora 42 RPM builds successfully (regression check)