### PR TITLE
fix(rpm): use explicit file paths in spec for Fedora 39/40/41 compatibility

### DIFF
--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -140,6 +140,7 @@ done
 %files
 %license COPYING
 %doc README NEWS
+# Configuration directories
 %dir %{_sysconfdir}/strongswan
 %dir %{_sysconfdir}/strongswan/ipsec.d
 %dir %attr(700,root,root) %{_sysconfdir}/strongswan/ipsec.d/aacerts
@@ -151,19 +152,48 @@ done
 %dir %attr(700,root,root) %{_sysconfdir}/strongswan/ipsec.d/private
 %dir %attr(700,root,root) %{_sysconfdir}/strongswan/ipsec.d/reqs
 %dir %{_sysconfdir}/swanctl
+%dir %{_sysconfdir}/swanctl/bliss
 %dir %{_sysconfdir}/swanctl/conf.d
+%dir %{_sysconfdir}/swanctl/ecdsa
+%dir %{_sysconfdir}/swanctl/pkcs8
+%dir %{_sysconfdir}/swanctl/pkcs12
+%dir %{_sysconfdir}/swanctl/private
+%dir %{_sysconfdir}/swanctl/pubkey
+%dir %{_sysconfdir}/swanctl/rsa
+%dir %{_sysconfdir}/swanctl/x509
+%dir %{_sysconfdir}/swanctl/x509aa
+%dir %{_sysconfdir}/swanctl/x509ac
+%dir %{_sysconfdir}/swanctl/x509ca
+%dir %{_sysconfdir}/swanctl/x509crl
+%dir %{_sysconfdir}/swanctl/x509ocsp
 %config(noreplace) %{_sysconfdir}/strongswan.conf
 %config(noreplace) %{_sysconfdir}/strongswan.d
-%{_sysconfdir}/swanctl/*
+%config(noreplace) %{_sysconfdir}/swanctl/swanctl.conf
+# Binaries
+%{_bindir}/pki
+%{_sbindir}/swanctl
+%{_sbindir}/charon-systemd
+# Systemd service
 %{_unitdir}/strongswan.service
-%{_sbindir}/*
+# Libraries and plugins
 %dir %{_libdir}/ipsec
 %dir %{_libdir}/ipsec/plugins
-%{_libdir}/ipsec/*
+%{_libdir}/ipsec/libcharon.so.0
+%{_libdir}/ipsec/libcharon.so.0.0.0
+%{_libdir}/ipsec/libstrongswan.so.0
+%{_libdir}/ipsec/libstrongswan.so.0.0.0
+%{_libdir}/ipsec/libvici.so.0
+%{_libdir}/ipsec/libvici.so.0.0.0
+%{_libdir}/ipsec/plugins/libstrongswan-*.so
 %exclude %{_libdir}/ipsec/plugins/libstrongswan-pgsql.so
 %exclude %{_libdir}/ipsec/plugins/libstrongswan-dhcp-inform.so
+# Data files
 %{_datadir}/strongswan
-%{_mandir}/man?/*
+# Man pages
+%{_mandir}/man1/pki*.1*
+%{_mandir}/man5/strongswan.conf.5*
+%{_mandir}/man5/swanctl.conf.5*
+%{_mandir}/man8/swanctl.8*
 
 %files -n strongswan-pgsql
 %{_libdir}/ipsec/plugins/libstrongswan-pgsql.so

--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -174,15 +174,30 @@ done
 %{_sbindir}/charon-systemd
 # Systemd service
 %{_unitdir}/strongswan.service
-# Libraries and plugins
+# Helper scripts and binaries
+%{_libdir}/ipsec/_updown
+%{_libdir}/ipsec/charon
+%{_libdir}/ipsec/pool
+%{_libdir}/ipsec/xfrmi
+# Libraries
 %dir %{_libdir}/ipsec
 %dir %{_libdir}/ipsec/plugins
+%{_libdir}/ipsec/libcharon.so
 %{_libdir}/ipsec/libcharon.so.0
 %{_libdir}/ipsec/libcharon.so.0.0.0
+%{_libdir}/ipsec/libradius.so
+%{_libdir}/ipsec/libradius.so.0
+%{_libdir}/ipsec/libradius.so.0.0.0
+%{_libdir}/ipsec/libstrongswan.so
 %{_libdir}/ipsec/libstrongswan.so.0
 %{_libdir}/ipsec/libstrongswan.so.0.0.0
+%{_libdir}/ipsec/libtls.so
+%{_libdir}/ipsec/libtls.so.0
+%{_libdir}/ipsec/libtls.so.0.0.0
+%{_libdir}/ipsec/libvici.so
 %{_libdir}/ipsec/libvici.so.0
 %{_libdir}/ipsec/libvici.so.0.0.0
+# Plugins
 %{_libdir}/ipsec/plugins/libstrongswan-*.so
 %exclude %{_libdir}/ipsec/plugins/libstrongswan-pgsql.so
 %exclude %{_libdir}/ipsec/plugins/libstrongswan-dhcp-inform.so

--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -152,14 +152,13 @@ done
 %dir %attr(700,root,root) %{_sysconfdir}/strongswan/ipsec.d/private
 %dir %attr(700,root,root) %{_sysconfdir}/strongswan/ipsec.d/reqs
 %dir %{_sysconfdir}/swanctl
-%dir %{_sysconfdir}/swanctl/bliss
 %dir %{_sysconfdir}/swanctl/conf.d
-%dir %{_sysconfdir}/swanctl/ecdsa
-%dir %{_sysconfdir}/swanctl/pkcs8
-%dir %{_sysconfdir}/swanctl/pkcs12
-%dir %{_sysconfdir}/swanctl/private
+%dir %attr(750,root,root) %{_sysconfdir}/swanctl/ecdsa
+%dir %attr(750,root,root) %{_sysconfdir}/swanctl/pkcs8
+%dir %attr(750,root,root) %{_sysconfdir}/swanctl/pkcs12
+%dir %attr(750,root,root) %{_sysconfdir}/swanctl/private
 %dir %{_sysconfdir}/swanctl/pubkey
-%dir %{_sysconfdir}/swanctl/rsa
+%dir %attr(750,root,root) %{_sysconfdir}/swanctl/rsa
 %dir %{_sysconfdir}/swanctl/x509
 %dir %{_sysconfdir}/swanctl/x509aa
 %dir %{_sysconfdir}/swanctl/x509ac

--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -179,7 +179,8 @@ done
 %{_libdir}/ipsec/charon
 %{_libdir}/ipsec/pool
 %{_libdir}/ipsec/xfrmi
-# Libraries
+# Libraries - explicit versions preferred over wildcards for traceability.
+# If upstream changes library versions, build failure alerts us to review.
 %dir %{_libdir}/ipsec
 %dir %{_libdir}/ipsec/plugins
 %{_libdir}/ipsec/libcharon.so


### PR DESCRIPTION
## Summary
- Add `/usr/bin/pki` explicitly (was missing, causing unpackaged file error)
- List all swanctl subdirectories explicitly instead of wildcard
- List binaries explicitly: pki, swanctl, charon-systemd
- List libraries with explicit version numbers
- Keep plugin wildcard (necessary for maintainability with 50+ plugins)
- List man pages explicitly
- Remove duplicate directory entries that caused "file listed twice" errors

## Problem
Fedora 39, 40, 41 builds failed with:
```
error: Installed (but unpackaged) file(s) found:
   /usr/bin/pki
   /usr/lib/debug/usr/bin/pki-*.debug
```

Fedora 42 passed due to different default behavior for unpackaged files.

## Test plan
- [ ] Verify Fedora 42 RPM builds successfully (PR build test)
- [ ] Verify Ubuntu DEB builds successfully (PR build test)