### PR TITLE
fix(ci): pass secrets to build-packages in sync-upstream workflow

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -153,5 +153,6 @@ jobs:
     uses: ./.github/workflows/build-packages.yml
     with:
       upstream_version: ${{ needs.check-release.outputs.upstream_version }}
+    secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Add `secrets: inherit` to reusable workflow call in sync-upstream.yml

## Problem
The sync-upstream workflow was failing at the publish step with:
```
##[error]Input required and not supplied: token
```

This happened because when calling `build-packages.yml` as a reusable workflow, secrets like `REPO_TOKEN`, `GPG_PASSPHRASE`, and `GPG_PRIVATE_KEY` were not being passed through.

## Solution
Add `secrets: inherit` to pass all repository secrets to the called workflow.

## Test plan
- [ ] Trigger sync-upstream workflow manually
- [ ] Verify publish step succeeds with access to repo repository