### PR TITLE
feat(dhcp-inform): add provider architecture for flexible route sources

### DIFF
--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -77,12 +77,17 @@ Enables storing VPN user credentials and configuration in PostgreSQL.
 %package -n strongswan-dhcp-inform
 Summary:        DHCP INFORM responder plugin for strongSwan
 Requires:       strongswan-sw = %{version}-%{release}
-# dhcp-inform plugin stores/retrieves split-tunnel routes in PostgreSQL database
-Requires:       strongswan-pgsql = %{version}-%{release}
+# Database is optional - plugin can work with static routes or TS routes
+Recommends:     strongswan-pgsql = %{version}-%{release}
 
 %description -n strongswan-dhcp-inform
-Responds to Windows DHCPINFORM requests with split-tunnel routes
-from PostgreSQL database. Delivers routes via DHCP option 121/249.
+Responds to Windows DHCPINFORM requests with split-tunnel routes.
+Delivers routes via DHCP option 121/249.
+
+Route sources (in priority order):
+1. Traffic Selectors - EXCLUSIVE mode for Windows 7 compatibility
+2. Database (PostgreSQL/MySQL/SQLite) - if configured
+3. Static configuration from strongswan.conf
 
 %prep
 %autosetup -n strongswan-%{upstream_version}-sw.%{sw_rev}

--- a/packaging/rpm/strongswan-sw.spec
+++ b/packaging/rpm/strongswan-sw.spec
@@ -77,7 +77,7 @@ Enables storing VPN user credentials and configuration in PostgreSQL.
 %package -n strongswan-dhcp-inform
 Summary:        DHCP INFORM responder plugin for strongSwan
 Requires:       strongswan-sw = %{version}-%{release}
-# Database is optional - plugin can work with static routes or TS routes
+# Database is optional - supports PostgreSQL/MySQL/SQLite via strongSwan SQL plugins
 Recommends:     strongswan-pgsql = %{version}-%{release}
 
 %description -n strongswan-dhcp-inform

--- a/src/libcharon/plugins/dhcp_inform/Makefile.am
+++ b/src/libcharon/plugins/dhcp_inform/Makefile.am
@@ -13,6 +13,10 @@ endif
 
 libstrongswan_dhcp_inform_la_SOURCES = \
 	dhcp_inform_plugin.h dhcp_inform_plugin.c \
-	dhcp_inform_responder.h dhcp_inform_responder.c
+	dhcp_inform_responder.h dhcp_inform_responder.c \
+	dhcp_inform_provider.h \
+	dhcp_inform_static_provider.h dhcp_inform_static_provider.c \
+	dhcp_inform_ts_provider.h dhcp_inform_ts_provider.c \
+	dhcp_inform_db_provider.h dhcp_inform_db_provider.c
 
 libstrongswan_dhcp_inform_la_LDFLAGS = -module -avoid-version

--- a/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
+++ b/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
@@ -6,7 +6,8 @@
 # 2. Database - when database URI configured
 # 3. Static configuration - when no database
 #
-# Modes are EXCLUSIVE - they never combine. Configure only ONE mode.
+# Modes are EXCLUSIVE - only the highest-priority configured mode is used.
+# If multiple modes are configured, lower-priority modes are silently ignored.
 
 dhcp-inform {
     # Enable the plugin

--- a/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
+++ b/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
@@ -35,9 +35,15 @@ dhcp-inform {
     # =========================================================================
     # Routes are queried from database by matching client IP to pool CIDR.
     # When database is configured, static routes are IGNORED.
-    # Requires v_pool_routes view: (pool_cidr, route)
+    # Works with PostgreSQL, MySQL, SQLite via strongSwan database abstraction.
     #
-    # database = postgresql://vpn_user:password@localhost/vpn_db
+    # Requires VIEW v_pool_routes (pool_cidr TEXT, route TEXT):
+    #   - pool_cidr: CIDR notation (e.g., "10.0.0.0/8")
+    #   - route: route to push to clients in this pool
+    #
+    # database = pgsql://vpn_user:password@localhost/vpn_db
+    # database = mysql://vpn_user:password@localhost/vpn_db
+    # database = sqlite:///etc/strongswan/routes.db
 
     # =========================================================================
     # MODE 3: Static Routes (EXCLUSIVE - only when no database)

--- a/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
+++ b/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
@@ -1,20 +1,72 @@
 # dhcp-inform plugin configuration
-# Responds to DHCPINFORM from Windows VPN clients with routes from database
+# Responds to DHCPINFORM from Windows VPN clients with split-tunnel routes
+#
+# THREE MUTUALLY EXCLUSIVE MODES (priority order):
+# 1. Traffic Selectors - when use_ts_routes=yes
+# 2. Database - when database URI configured
+# 3. Static configuration - when no database
+#
+# Modes are EXCLUSIVE - they never combine. Configure only ONE mode.
 
 dhcp-inform {
     # Enable the plugin
     load = yes
 
-    # PostgreSQL database connection
-    # Same as attr-sql database
-    database = postgresql://vpn_strongswan:<PASSWORD>@localhost/vpn_admin
-
-    # VPN interface to listen on (optional, listens on all if not set)
-    interface = eth0
-
     # Server IP address (required - usually the VPN gateway IP)
     server = 172.16.69.1
 
+    # VPN interface to listen on (optional, listens on all if not set)
+    # interface = eth0
+
     # DNS server to advertise (optional)
-    dns = 172.16.69.1
+    # dns = 172.16.69.1
+
+    # =========================================================================
+    # MODE 1: Traffic Selector Routes (EXCLUSIVE)
+    # =========================================================================
+    # Routes are extracted from IKE SA traffic selectors.
+    # Designed for Windows 7 compatibility (doesn't handle TS properly).
+    # When enabled, database and static routes are IGNORED.
+    #
+    # use_ts_routes = yes
+
+    # =========================================================================
+    # MODE 2: Database Routes (EXCLUSIVE)
+    # =========================================================================
+    # Routes are queried from database by matching client IP to pool CIDR.
+    # When database is configured, static routes are IGNORED.
+    # Requires v_pool_routes view: (pool_cidr, route)
+    #
+    # database = postgresql://vpn_user:password@localhost/vpn_db
+
+    # =========================================================================
+    # MODE 3: Static Routes (EXCLUSIVE - only when no database)
+    # =========================================================================
+    # Used ONLY when no database is configured.
+    #
+    # Global routes - apply to all clients not matching a specific pool:
+    #
+    # routes {
+    #     route1 = 10.0.0.0/8
+    #     route2 = 172.16.0.0/12
+    #     route3 = 192.168.0.0/16
+    # }
+    #
+    # Per-pool route overrides - clients matching pool CIDR get these instead:
+    #
+    # pools {
+    #     production {
+    #         cidr = 10.100.0.0/16
+    #         routes {
+    #             r1 = 192.168.1.0/24
+    #             r2 = 192.168.2.0/24
+    #         }
+    #     }
+    #     development {
+    #         cidr = 10.200.0.0/16
+    #         routes {
+    #             r1 = 10.50.0.0/16
+    #         }
+    #     }
+    # }
 }

--- a/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
+++ b/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
@@ -1,13 +1,13 @@
 # dhcp-inform plugin configuration
 # Responds to DHCPINFORM from Windows VPN clients with split-tunnel routes
 #
-# THREE MUTUALLY EXCLUSIVE MODES (priority order):
+# PRIORITY-BASED ROUTE SELECTION (first available wins):
 # 1. Traffic Selectors - when use_ts_routes=yes
 # 2. Database - when database URI configured
-# 3. Static configuration - when no database
+# 3. Static configuration - fallback when above unavailable
 #
-# Modes are EXCLUSIVE - only the highest-priority configured mode is used.
-# If multiple modes are configured, lower-priority modes are silently ignored.
+# Only ONE source is used per request. Multiple sources can be configured
+# for graceful fallback - highest-priority available source is selected.
 
 dhcp-inform {
     # Enable the plugin
@@ -23,19 +23,19 @@ dhcp-inform {
     # dns = 172.16.69.1
 
     # =========================================================================
-    # MODE 1: Traffic Selector Routes (EXCLUSIVE)
+    # MODE 1: Traffic Selector Routes (highest priority)
     # =========================================================================
     # Routes are extracted from IKE SA traffic selectors.
     # Designed for Windows 7 compatibility (doesn't handle TS properly).
-    # When enabled, database and static routes are IGNORED.
+    # When enabled, this source takes priority over database and static.
     #
     # use_ts_routes = yes
 
     # =========================================================================
-    # MODE 2: Database Routes (EXCLUSIVE)
+    # MODE 2: Database Routes (second priority)
     # =========================================================================
     # Routes are queried from database by matching client IP to pool CIDR.
-    # When database is configured, static routes are IGNORED.
+    # Used when TS routes disabled. Takes priority over static routes.
     # Works with PostgreSQL, MySQL, SQLite via strongSwan database abstraction.
     #
     # Requires VIEW v_pool_routes (pool_cidr TEXT, route TEXT):
@@ -47,9 +47,9 @@ dhcp-inform {
     # database = sqlite:///etc/strongswan/routes.db
 
     # =========================================================================
-    # MODE 3: Static Routes (EXCLUSIVE - only when no database)
+    # MODE 3: Static Routes (fallback)
     # =========================================================================
-    # Used ONLY when no database is configured.
+    # Used when TS routes disabled and no database configured.
     #
     # Global routes - apply to all clients not matching a specific pool:
     #

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -1,0 +1,249 @@
+/*
+ * Copyright (C) 2025 Structured World Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ */
+
+#include "dhcp_inform_db_provider.h"
+
+#include <daemon.h>
+#include <collections/linked_list.h>
+#include <database/database.h>
+#include <selectors/traffic_selector.h>
+#include <networking/host.h>
+
+typedef struct private_dhcp_inform_db_provider_t private_dhcp_inform_db_provider_t;
+
+/**
+ * Private data
+ */
+struct private_dhcp_inform_db_provider_t {
+
+	/**
+	 * Public interface
+	 */
+	dhcp_inform_db_provider_t public;
+
+	/**
+	 * Database connection
+	 */
+	database_t *db;
+};
+
+/**
+ * Parse CIDR notation to traffic_selector
+ */
+static traffic_selector_t *parse_cidr(const char *cidr)
+{
+	char *slash, *ip_str;
+	int prefix = 32;
+	host_t *host;
+	traffic_selector_t *ts = NULL;
+
+	if (!cidr || !*cidr)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-db: CORRUPTED DATA - empty CIDR");
+		return NULL;
+	}
+
+	if (strlen(cidr) > 43)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-db: CORRUPTED DATA - CIDR too long: %.20s...",
+			 cidr);
+		return NULL;
+	}
+
+	ip_str = strdup(cidr);
+	if (!ip_str)
+	{
+		return NULL;
+	}
+
+	slash = strchr(ip_str, '/');
+	if (slash)
+	{
+		*slash = '\0';
+		prefix = atoi(slash + 1);
+		if (prefix < 0 || prefix > 32)
+		{
+			DBG1(DBG_CFG, "dhcp-inform-db: invalid prefix %d in %s",
+				 prefix, cidr);
+			free(ip_str);
+			return NULL;
+		}
+	}
+
+	host = host_create_from_string(ip_str, 0);
+	if (!host)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-db: invalid IP in CIDR: %s", ip_str);
+		free(ip_str);
+		return NULL;
+	}
+
+	ts = traffic_selector_create_from_subnet(host, prefix, 0, 0, 65535);
+	host->destroy(host);
+	free(ip_str);
+
+	return ts;
+}
+
+METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
+	private_dhcp_inform_db_provider_t *this, const char *client_ip)
+{
+	linked_list_t *routes;
+	enumerator_t *enumerator;
+	char *route_value;
+	int routes_parsed = 0;
+	int routes_failed = 0;
+
+	routes = linked_list_create();
+
+	if (!this->db)
+	{
+		return routes;
+	}
+
+	if (!client_ip || !*client_ip)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-db: CORRUPTED DATA - empty client IP");
+		return routes;
+	}
+
+	DBG2(DBG_CFG, "dhcp-inform-db: looking up routes for IP %s", client_ip);
+
+	/* Query routes for the pool that contains this IP
+	 * Uses v_pool_routes VIEW: (pool_cidr, route)
+	 */
+	enumerator = this->db->query(this->db,
+		"SELECT route FROM v_pool_routes WHERE ?::inet << pool_cidr::inet",
+		DB_TEXT, client_ip,
+		DB_TEXT);
+
+	if (!enumerator)
+	{
+		DBG2(DBG_CFG, "dhcp-inform-db: primary query failed, trying fallback");
+		/* Fallback: get routes from auto_ip_pools directly */
+		enumerator = this->db->query(this->db,
+			"SELECT unnest(aip.routes) as route "
+			"FROM auto_ip_pools aip "
+			"JOIN environments e ON e.auto_ip_pool_id = aip.id "
+			"WHERE e.is_active = true "
+			"AND ?::inet << aip.cidr::inet",
+			DB_TEXT, client_ip,
+			DB_TEXT);
+	}
+
+	if (!enumerator)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-db: all queries failed for %s", client_ip);
+		return routes;
+	}
+
+	while (enumerator->enumerate(enumerator, &route_value))
+	{
+		traffic_selector_t *ts;
+
+		routes_parsed++;
+
+		if (!route_value)
+		{
+			DBG1(DBG_CFG, "dhcp-inform-db: CORRUPTED DATA - NULL route at row %d",
+				 routes_parsed);
+			routes_failed++;
+			continue;
+		}
+
+		ts = parse_cidr(route_value);
+		if (ts)
+		{
+			routes->insert_last(routes, ts);
+			DBG2(DBG_CFG, "dhcp-inform-db: added route %s", route_value);
+		}
+		else
+		{
+			DBG1(DBG_CFG, "dhcp-inform-db: failed to parse route: %s",
+				 route_value);
+			routes_failed++;
+		}
+	}
+	enumerator->destroy(enumerator);
+
+	if (routes_failed > 0)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-db: WARNING - %d/%d routes had corrupted data",
+			 routes_failed, routes_parsed);
+	}
+
+	DBG1(DBG_CFG, "dhcp-inform-db: found %d valid routes for %s",
+		 routes->get_count(routes), client_ip);
+
+	return routes;
+}
+
+METHOD(dhcp_inform_provider_t, get_name, const char*,
+	private_dhcp_inform_db_provider_t *this)
+{
+	return "database";
+}
+
+METHOD(dhcp_inform_provider_t, is_available, bool,
+	private_dhcp_inform_db_provider_t *this)
+{
+	return this->db != NULL;
+}
+
+METHOD(dhcp_inform_provider_t, destroy, void,
+	private_dhcp_inform_db_provider_t *this)
+{
+	DESTROY_IF(this->db);
+	free(this);
+}
+
+/**
+ * See header
+ */
+dhcp_inform_db_provider_t *dhcp_inform_db_provider_create()
+{
+	private_dhcp_inform_db_provider_t *this;
+	char *db_uri;
+
+	INIT(this,
+		.public = {
+			.provider = {
+				.get_routes = _get_routes,
+				.get_name = _get_name,
+				.is_available = _is_available,
+				.destroy = _destroy,
+			},
+		},
+	);
+
+	/* Get database URI from configuration */
+	db_uri = lib->settings->get_str(lib->settings,
+		"%s.plugins.dhcp-inform.database", NULL, lib->ns);
+
+	if (db_uri)
+	{
+		this->db = lib->db->create(lib->db, db_uri);
+		if (this->db)
+		{
+			DBG1(DBG_CFG, "dhcp-inform: database provider connected");
+		}
+		else
+		{
+			DBG1(DBG_CFG, "dhcp-inform: failed to connect to database, "
+				 "database provider disabled");
+		}
+	}
+	else
+	{
+		DBG2(DBG_CFG, "dhcp-inform: no database configured, "
+			 "database provider disabled");
+	}
+
+	return &this->public;
+}

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -40,6 +40,8 @@ struct private_dhcp_inform_db_provider_t {
 
 /**
  * Parse CIDR to host and prefix.
+ * Prefix 0 (match-all) is allowed for admin flexibility.
+ * Note: Duplicated for self-contained compilation (see static_provider).
  */
 static bool parse_cidr_to_host(const char *cidr, host_t **host, uint8_t *prefix)
 {

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -33,7 +33,9 @@ struct private_dhcp_inform_db_provider_t {
 	database_t *db;
 };
 
-/* Maximum CIDR string length: "xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx/128" = 43 chars */
+/* Maximum CIDR string length for IPv4: "255.255.255.255/32" = 18 chars.
+ * Note: DHCP option 121/249 (classless static routes) is IPv4-only.
+ * Using 43 to be safe with any reasonable input. */
 #define MAX_CIDR_LEN 43
 
 /**

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.h
@@ -22,15 +22,18 @@ typedef struct dhcp_inform_db_provider_t dhcp_inform_db_provider_t;
 /**
  * Database route provider - reads routes from SQL database.
  *
- * Supports PostgreSQL, MySQL, SQLite via strongSwan database abstraction.
- * Queries routes from v_pool_routes view based on client virtual IP.
+ * Works with PostgreSQL, MySQL, SQLite via strongSwan database abstraction.
+ * Uses portable SQL; IP-in-CIDR filtering done in C for compatibility.
  *
  * Configuration:
  *   charon.plugins.dhcp-inform.database = pgsql://user:pass@host/db
+ *   charon.plugins.dhcp-inform.database = mysql://user:pass@host/db
+ *   charon.plugins.dhcp-inform.database = sqlite:///path/to/db.sqlite
  *
  * Required database schema:
- *   VIEW v_pool_routes (pool_cidr, route)
- *   - Returns routes for pools, client IP matched against pool_cidr
+ *   VIEW v_pool_routes (pool_cidr TEXT, route TEXT)
+ *   - pool_cidr: CIDR notation (e.g., "10.0.0.0/8")
+ *   - route: route to push to clients in this pool (CIDR notation)
  */
 struct dhcp_inform_db_provider_t {
 

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Structured World Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ */
+
+/**
+ * @defgroup dhcp_inform_db_provider dhcp_inform_db_provider
+ * @{ @ingroup dhcp_inform
+ */
+
+#ifndef DHCP_INFORM_DB_PROVIDER_H_
+#define DHCP_INFORM_DB_PROVIDER_H_
+
+#include "dhcp_inform_provider.h"
+
+typedef struct dhcp_inform_db_provider_t dhcp_inform_db_provider_t;
+
+/**
+ * Database route provider - reads routes from SQL database.
+ *
+ * Supports PostgreSQL, MySQL, SQLite via strongSwan database abstraction.
+ * Queries routes from v_pool_routes view based on client virtual IP.
+ *
+ * Configuration:
+ *   charon.plugins.dhcp-inform.database = pgsql://user:pass@host/db
+ *
+ * Required database schema:
+ *   VIEW v_pool_routes (pool_cidr, route)
+ *   - Returns routes for pools, client IP matched against pool_cidr
+ */
+struct dhcp_inform_db_provider_t {
+
+	/**
+	 * Implements dhcp_inform_provider_t interface
+	 */
+	dhcp_inform_provider_t provider;
+};
+
+/**
+ * Create database route provider.
+ *
+ * @return				provider instance, NULL on failure
+ */
+dhcp_inform_db_provider_t *dhcp_inform_db_provider_create();
+
+#endif /** DHCP_INFORM_DB_PROVIDER_H_ @}*/

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_plugin.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_plugin.c
@@ -7,6 +7,18 @@
  * option) any later version.
  */
 
+/**
+ * DHCP INFORM Plugin - responds to Windows DHCPINFORM with routes.
+ *
+ * Route sources (in priority order):
+ * 1. Traffic Selectors (EXCLUSIVE mode - when enabled, only TS routes used)
+ * 2. Database (PostgreSQL/MySQL/SQLite - optional)
+ * 3. Static configuration (from strongswan.conf)
+ *
+ * The plugin works WITHOUT any database if static routes or TS routes are
+ * configured. Database plugins are soft dependencies.
+ */
+
 #include "dhcp_inform_plugin.h"
 #include "dhcp_inform_responder.h"
 
@@ -65,8 +77,9 @@ METHOD(plugin_t, get_features, int,
 	static plugin_feature_t f[] = {
 		PLUGIN_CALLBACK((plugin_feature_callback_t)plugin_cb, NULL),
 			PLUGIN_PROVIDE(CUSTOM, "dhcp-inform"),
-				PLUGIN_DEPENDS(DATABASE, DB_PGSQL),
-				PLUGIN_SDEPEND(CUSTOM, "attr-sql"),
+				/* Database plugins are optional - plugin works with static
+				 * routes or TS routes without any database */
+				PLUGIN_SDEPEND(DATABASE, DB_ANY),
 	};
 	*features = f;
 	return countof(f);

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_plugin.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_plugin.h
@@ -8,11 +8,11 @@
  */
 
 /**
- * @defgroup dhcp_inform_p dhcp_inform
+ * @defgroup dhcp_inform dhcp_inform
  * @ingroup cplugins
  *
  * @defgroup dhcp_inform_plugin dhcp_inform_plugin
- * @{ @ingroup dhcp_inform_p
+ * @{ @ingroup dhcp_inform
  */
 
 #ifndef DHCP_INFORM_PLUGIN_H_
@@ -23,16 +23,17 @@
 typedef struct dhcp_inform_plugin_t dhcp_inform_plugin_t;
 
 /**
- * Plugin responding to DHCPINFORM with routes from PostgreSQL database.
+ * Plugin responding to DHCPINFORM with split-tunnel routes.
  *
  * Windows VPN clients send DHCPINFORM after IKEv2 connection to get
- * split-tunnel routes via DHCP option 249 (Microsoft Classless Static Routes).
+ * split-tunnel routes via DHCP option 121/249.
  *
- * This plugin:
- * - Listens for DHCPINFORM on the VPN interface
- * - Looks up routes by matching client's virtual IP to network pool CIDR
- * - Queries PostgreSQL for routes configured in the pool's environment
- * - Responds with DHCPACK containing option 121/249 with routes
+ * Route sources (in priority order):
+ * 1. Traffic Selectors - EXCLUSIVE mode (for Windows 7 compatibility)
+ * 2. Database (PostgreSQL/MySQL/SQLite) - if configured
+ * 3. Static configuration from strongswan.conf
+ *
+ * The plugin works WITHOUT any database when using static or TS routes.
  */
 struct dhcp_inform_plugin_t {
 

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_provider.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_provider.h
@@ -34,8 +34,9 @@ struct dhcp_inform_provider_t {
 	 *
 	 * @param this			provider instance
 	 * @param client_ip		client's virtual IP address string
-	 * @return				linked_list_t of traffic_selector_t (caller destroys),
-	 *						or NULL on error
+	 * @return				linked_list_t of traffic_selector_t (caller destroys).
+	 *						Returns valid list (possibly empty) on success.
+	 *						NULL indicates allocation failure; callers must handle.
 	 */
 	linked_list_t* (*get_routes)(dhcp_inform_provider_t *this,
 								 const char *client_ip);

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_provider.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_provider.h
@@ -32,6 +32,7 @@ struct dhcp_inform_provider_t {
 	/**
 	 * Get routes for a client by virtual IP.
 	 *
+	 * @param this			provider instance
 	 * @param client_ip		client's virtual IP address string
 	 * @return				linked_list_t of traffic_selector_t (caller destroys),
 	 *						or NULL on error
@@ -42,6 +43,7 @@ struct dhcp_inform_provider_t {
 	/**
 	 * Get provider name for logging.
 	 *
+	 * @param this			provider instance
 	 * @return				provider name string (static, do not free)
 	 */
 	const char* (*get_name)(dhcp_inform_provider_t *this);
@@ -49,12 +51,15 @@ struct dhcp_inform_provider_t {
 	/**
 	 * Check if provider is available/configured.
 	 *
+	 * @param this			provider instance
 	 * @return				TRUE if provider can provide routes
 	 */
 	bool (*is_available)(dhcp_inform_provider_t *this);
 
 	/**
 	 * Destroy provider instance.
+	 *
+	 * @param this			provider instance
 	 */
 	void (*destroy)(dhcp_inform_provider_t *this);
 };

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_provider.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_provider.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 Structured World Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ */
+
+/**
+ * @defgroup dhcp_inform_provider dhcp_inform_provider
+ * @{ @ingroup dhcp_inform
+ */
+
+#ifndef DHCP_INFORM_PROVIDER_H_
+#define DHCP_INFORM_PROVIDER_H_
+
+#include <collections/linked_list.h>
+
+typedef struct dhcp_inform_provider_t dhcp_inform_provider_t;
+
+/**
+ * Route provider interface for DHCP INFORM plugin.
+ *
+ * Implementations provide routes from different sources:
+ * - Database (pgsql/mysql/sqlite)
+ * - Static configuration
+ * - IKE Traffic Selectors
+ */
+struct dhcp_inform_provider_t {
+
+	/**
+	 * Get routes for a client by virtual IP.
+	 *
+	 * @param client_ip		client's virtual IP address string
+	 * @return				linked_list_t of traffic_selector_t (caller destroys),
+	 *						or NULL on error
+	 */
+	linked_list_t* (*get_routes)(dhcp_inform_provider_t *this,
+								 const char *client_ip);
+
+	/**
+	 * Get provider name for logging.
+	 *
+	 * @return				provider name string (static, do not free)
+	 */
+	const char* (*get_name)(dhcp_inform_provider_t *this);
+
+	/**
+	 * Check if provider is available/configured.
+	 *
+	 * @return				TRUE if provider can provide routes
+	 */
+	bool (*is_available)(dhcp_inform_provider_t *this);
+
+	/**
+	 * Destroy provider instance.
+	 */
+	void (*destroy)(dhcp_inform_provider_t *this);
+};
+
+#endif /** DHCP_INFORM_PROVIDER_H_ @}*/

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -722,7 +722,7 @@ static void process_dhcp_packet(private_dhcp_inform_responder_t *this,
 	inet_ntop(AF_INET, &dhcp->ciaddr, client_ip_str, sizeof(client_ip_str));
 	DBG1(DBG_NET, "dhcp-inform: received DHCPINFORM from %s", client_ip_str);
 
-	/* Get routes from providers (TS exclusive, or DB + static combined) */
+	/* Get routes from providers (mutually exclusive: TS OR DB OR static) */
 	routes = get_routes_for_client(this, client_ip_str);
 
 	if (!routes)

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -209,6 +209,11 @@ static void add_routes_from_provider(dhcp_inform_provider_t *provider,
 	enumerator = provider_routes->create_enumerator(provider_routes);
 	while (enumerator->enumerate(enumerator, &ts))
 	{
+		if (!ts)
+		{
+			/* Skip NULL entries that may result from failed clone operations */
+			continue;
+		}
 		if (route_exists_in_list(routes, ts))
 		{
 			duplicates++;

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -240,13 +240,13 @@ static void add_routes_from_provider(dhcp_inform_provider_t *provider,
 /**
  * Get routes for client using available providers.
  *
- * THREE MUTUALLY EXCLUSIVE MODES (priority order):
- * 1. TS routes - when use_ts_routes=yes, ONLY traffic selector routes
- * 2. DB routes - when database configured, ONLY database routes
- * 3. Static routes - when no DB, use config routes with per-pool overrides
+ * PRIORITY-BASED ROUTE SELECTION (first available wins):
+ * 1. TS routes - when use_ts_routes=yes, traffic selectors from IKE SA
+ * 2. DB routes - when database configured, routes from SQL database
+ * 3. Static routes - fallback to config routes with per-pool overrides
  *
- * Modes are exclusive - if multiple are configured, highest priority wins.
- * This is intentional: config errors don't crash, just use first available mode.
+ * Only ONE source is used per request. Multiple sources can be configured
+ * for graceful fallback - highest-priority available source is selected.
  */
 static linked_list_t *get_routes_for_client(private_dhcp_inform_responder_t *this,
 											const char *client_ip)

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup dhcp_inform_responder dhcp_inform_responder
- * @{ @ingroup dhcp_inform_p
+ * @{ @ingroup dhcp_inform
  */
 
 #ifndef DHCP_INFORM_RESPONDER_H_
@@ -18,7 +18,7 @@
 typedef struct dhcp_inform_responder_t dhcp_inform_responder_t;
 
 /**
- * DHCPINFORM responder that sends routes from database.
+ * DHCPINFORM responder that sends routes via DHCP option 121/249.
  */
 struct dhcp_inform_responder_t {
 

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
@@ -1,0 +1,466 @@
+/*
+ * Copyright (C) 2025 Structured World Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ */
+
+#include "dhcp_inform_static_provider.h"
+
+#include <daemon.h>
+#include <collections/linked_list.h>
+#include <networking/host.h>
+#include <selectors/traffic_selector.h>
+
+typedef struct private_dhcp_inform_static_provider_t private_dhcp_inform_static_provider_t;
+
+/**
+ * Pool configuration entry
+ */
+typedef struct {
+	/** Pool name (informational) */
+	char *name;
+	/** Pool CIDR as host_t with prefix */
+	host_t *network;
+	/** Prefix length */
+	uint8_t prefix;
+	/** Routes for this pool */
+	linked_list_t *routes;
+} pool_entry_t;
+
+/**
+ * Private data
+ */
+struct private_dhcp_inform_static_provider_t {
+
+	/**
+	 * Public interface
+	 */
+	dhcp_inform_static_provider_t public;
+
+	/**
+	 * Global routes (apply to all clients not matching a pool)
+	 */
+	linked_list_t *global_routes;
+
+	/**
+	 * Per-pool route configurations
+	 */
+	linked_list_t *pools;
+
+	/**
+	 * Whether any routes are configured
+	 */
+	bool has_routes;
+};
+
+/**
+ * Destroy a pool entry
+ */
+static void pool_entry_destroy(pool_entry_t *entry)
+{
+	if (entry)
+	{
+		free(entry->name);
+		DESTROY_IF(entry->network);
+		if (entry->routes)
+		{
+			entry->routes->destroy_offset(entry->routes,
+				offsetof(traffic_selector_t, destroy));
+		}
+		free(entry);
+	}
+}
+
+/**
+ * Parse CIDR notation to traffic_selector
+ */
+static traffic_selector_t *parse_cidr(const char *cidr)
+{
+	char *slash, *ip_str;
+	int prefix = 32;
+	host_t *host;
+	traffic_selector_t *ts = NULL;
+
+	if (!cidr || !*cidr)
+	{
+		return NULL;
+	}
+
+	if (strlen(cidr) > 43)
+	{
+		DBG1(DBG_CFG, "dhcp-inform: CIDR too long: %.20s...", cidr);
+		return NULL;
+	}
+
+	ip_str = strdup(cidr);
+	if (!ip_str)
+	{
+		return NULL;
+	}
+
+	slash = strchr(ip_str, '/');
+	if (slash)
+	{
+		*slash = '\0';
+		prefix = atoi(slash + 1);
+		if (prefix < 0 || prefix > 32)
+		{
+			DBG1(DBG_CFG, "dhcp-inform: invalid prefix %d in %s", prefix, cidr);
+			free(ip_str);
+			return NULL;
+		}
+	}
+
+	host = host_create_from_string(ip_str, 0);
+	if (!host)
+	{
+		DBG1(DBG_CFG, "dhcp-inform: invalid IP in CIDR: %s", ip_str);
+		free(ip_str);
+		return NULL;
+	}
+
+	ts = traffic_selector_create_from_subnet(host, prefix, 0, 0, 65535);
+	host->destroy(host);
+	free(ip_str);
+
+	return ts;
+}
+
+/**
+ * Parse CIDR to host and prefix for pool matching
+ */
+static bool parse_cidr_to_host(const char *cidr, host_t **host, uint8_t *prefix)
+{
+	char *slash, *ip_str;
+	int pfx = 32;
+
+	if (!cidr || !*cidr)
+	{
+		return FALSE;
+	}
+
+	ip_str = strdup(cidr);
+	if (!ip_str)
+	{
+		return FALSE;
+	}
+
+	slash = strchr(ip_str, '/');
+	if (slash)
+	{
+		*slash = '\0';
+		pfx = atoi(slash + 1);
+		if (pfx < 0 || pfx > 32)
+		{
+			free(ip_str);
+			return FALSE;
+		}
+	}
+
+	*host = host_create_from_string(ip_str, 0);
+	free(ip_str);
+
+	if (!*host)
+	{
+		return FALSE;
+	}
+
+	*prefix = pfx;
+	return TRUE;
+}
+
+/**
+ * Check if an IP address falls within a network/prefix
+ */
+static bool ip_in_subnet(host_t *ip, host_t *network, uint8_t prefix)
+{
+	chunk_t ip_addr, net_addr;
+	uint8_t *ip_ptr, *net_ptr;
+	int bytes, bits, i;
+	uint8_t mask;
+
+	if (ip->get_family(ip) != network->get_family(network))
+	{
+		return FALSE;
+	}
+
+	ip_addr = ip->get_address(ip);
+	net_addr = network->get_address(network);
+
+	if (ip_addr.len != net_addr.len)
+	{
+		return FALSE;
+	}
+
+	bytes = prefix / 8;
+	bits = prefix % 8;
+
+	ip_ptr = ip_addr.ptr;
+	net_ptr = net_addr.ptr;
+
+	/* Compare full bytes */
+	for (i = 0; i < bytes && i < (int)ip_addr.len; i++)
+	{
+		if (ip_ptr[i] != net_ptr[i])
+		{
+			return FALSE;
+		}
+	}
+
+	/* Compare remaining bits */
+	if (bits > 0 && bytes < (int)ip_addr.len)
+	{
+		mask = 0xFF << (8 - bits);
+		if ((ip_ptr[bytes] & mask) != (net_ptr[bytes] & mask))
+		{
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
+/**
+ * Load routes from a config section
+ */
+static linked_list_t *load_routes_from_section(const char *section)
+{
+	linked_list_t *routes;
+	enumerator_t *enumerator;
+	char *key, *value;
+	int count = 0;
+
+	routes = linked_list_create();
+
+	enumerator = lib->settings->create_key_value_enumerator(lib->settings,
+		"%s.plugins.dhcp-inform.%s", lib->ns, section);
+
+	while (enumerator->enumerate(enumerator, &key, &value))
+	{
+		traffic_selector_t *ts = parse_cidr(value);
+		if (ts)
+		{
+			routes->insert_last(routes, ts);
+			count++;
+			DBG2(DBG_CFG, "dhcp-inform: loaded static route %s from %s",
+				 value, section);
+		}
+		else
+		{
+			DBG1(DBG_CFG, "dhcp-inform: failed to parse route '%s' in %s",
+				 value, section);
+		}
+	}
+	enumerator->destroy(enumerator);
+
+	return routes;
+}
+
+/**
+ * Load pool configurations
+ */
+static void load_pools(private_dhcp_inform_static_provider_t *this)
+{
+	enumerator_t *pool_enum;
+	char *pool_name;
+
+	pool_enum = lib->settings->create_section_enumerator(lib->settings,
+		"%s.plugins.dhcp-inform.pools", lib->ns);
+
+	while (pool_enum->enumerate(pool_enum, &pool_name))
+	{
+		char *cidr;
+		char routes_section[256];
+		pool_entry_t *entry;
+		host_t *network;
+		uint8_t prefix;
+
+		cidr = lib->settings->get_str(lib->settings,
+			"%s.plugins.dhcp-inform.pools.%s.cidr", NULL, lib->ns, pool_name);
+
+		if (!cidr)
+		{
+			DBG1(DBG_CFG, "dhcp-inform: pool '%s' missing cidr, skipping",
+				 pool_name);
+			continue;
+		}
+
+		if (!parse_cidr_to_host(cidr, &network, &prefix))
+		{
+			DBG1(DBG_CFG, "dhcp-inform: pool '%s' invalid cidr '%s', skipping",
+				 pool_name, cidr);
+			continue;
+		}
+
+		INIT(entry,
+			.name = strdup(pool_name),
+			.network = network,
+			.prefix = prefix,
+		);
+
+		snprintf(routes_section, sizeof(routes_section),
+				 "pools.%s.routes", pool_name);
+		entry->routes = load_routes_from_section(routes_section);
+
+		if (entry->routes->get_count(entry->routes) > 0)
+		{
+			this->pools->insert_last(this->pools, entry);
+			this->has_routes = TRUE;
+			DBG1(DBG_CFG, "dhcp-inform: loaded pool '%s' (%s) with %d routes",
+				 pool_name, cidr, entry->routes->get_count(entry->routes));
+		}
+		else
+		{
+			DBG1(DBG_CFG, "dhcp-inform: pool '%s' has no routes, skipping",
+				 pool_name);
+			pool_entry_destroy(entry);
+		}
+	}
+	pool_enum->destroy(pool_enum);
+}
+
+/**
+ * Clone routes from a list
+ */
+static linked_list_t *clone_routes(linked_list_t *source)
+{
+	linked_list_t *cloned;
+	enumerator_t *enumerator;
+	traffic_selector_t *ts;
+
+	cloned = linked_list_create();
+	enumerator = source->create_enumerator(source);
+	while (enumerator->enumerate(enumerator, &ts))
+	{
+		cloned->insert_last(cloned, ts->clone(ts));
+	}
+	enumerator->destroy(enumerator);
+
+	return cloned;
+}
+
+METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
+	private_dhcp_inform_static_provider_t *this, const char *client_ip)
+{
+	enumerator_t *enumerator;
+	pool_entry_t *pool;
+	host_t *client;
+
+	if (!client_ip)
+	{
+		/* No client IP - return global routes */
+		if (this->global_routes->get_count(this->global_routes) > 0)
+		{
+			DBG2(DBG_CFG, "dhcp-inform: returning global routes (no client IP)");
+			return clone_routes(this->global_routes);
+		}
+		return linked_list_create();
+	}
+
+	client = host_create_from_string(client_ip, 0);
+	if (!client)
+	{
+		DBG1(DBG_CFG, "dhcp-inform: invalid client IP: %s", client_ip);
+		return linked_list_create();
+	}
+
+	/* Check pool-specific routes first */
+	enumerator = this->pools->create_enumerator(this->pools);
+	while (enumerator->enumerate(enumerator, &pool))
+	{
+		if (ip_in_subnet(client, pool->network, pool->prefix))
+		{
+			enumerator->destroy(enumerator);
+			client->destroy(client);
+
+			DBG1(DBG_CFG, "dhcp-inform: client %s matched pool '%s', "
+				 "returning %d pool-specific routes",
+				 client_ip, pool->name, pool->routes->get_count(pool->routes));
+
+			return clone_routes(pool->routes);
+		}
+	}
+	enumerator->destroy(enumerator);
+	client->destroy(client);
+
+	/* Fall back to global routes */
+	if (this->global_routes->get_count(this->global_routes) > 0)
+	{
+		DBG1(DBG_CFG, "dhcp-inform: client %s using %d global routes",
+			 client_ip, this->global_routes->get_count(this->global_routes));
+		return clone_routes(this->global_routes);
+	}
+
+	DBG1(DBG_CFG, "dhcp-inform: no routes configured for client %s", client_ip);
+	return linked_list_create();
+}
+
+METHOD(dhcp_inform_provider_t, get_name, const char*,
+	private_dhcp_inform_static_provider_t *this)
+{
+	return "static";
+}
+
+METHOD(dhcp_inform_provider_t, is_available, bool,
+	private_dhcp_inform_static_provider_t *this)
+{
+	return this->has_routes;
+}
+
+METHOD(dhcp_inform_provider_t, destroy, void,
+	private_dhcp_inform_static_provider_t *this)
+{
+	if (this->global_routes)
+	{
+		this->global_routes->destroy_offset(this->global_routes,
+			offsetof(traffic_selector_t, destroy));
+	}
+	if (this->pools)
+	{
+		this->pools->destroy_function(this->pools, (void*)pool_entry_destroy);
+	}
+	free(this);
+}
+
+/**
+ * See header
+ */
+dhcp_inform_static_provider_t *dhcp_inform_static_provider_create()
+{
+	private_dhcp_inform_static_provider_t *this;
+
+	INIT(this,
+		.public = {
+			.provider = {
+				.get_routes = _get_routes,
+				.get_name = _get_name,
+				.is_available = _is_available,
+				.destroy = _destroy,
+			},
+		},
+		.pools = linked_list_create(),
+		.has_routes = FALSE,
+	);
+
+	/* Load global routes */
+	this->global_routes = load_routes_from_section("routes");
+	if (this->global_routes->get_count(this->global_routes) > 0)
+	{
+		this->has_routes = TRUE;
+		DBG1(DBG_CFG, "dhcp-inform: loaded %d global static routes",
+			 this->global_routes->get_count(this->global_routes));
+	}
+
+	/* Load per-pool routes */
+	load_pools(this);
+
+	if (!this->has_routes)
+	{
+		DBG2(DBG_CFG, "dhcp-inform: no static routes configured");
+	}
+
+	return &this->public;
+}

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
@@ -360,7 +360,7 @@ METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
 		return linked_list_create();
 	}
 
-	client = host_create_from_string(client_ip, 0);
+	client = host_create_from_string((char*)client_ip, 0);
 	if (!client)
 	{
 		DBG1(DBG_CFG, "dhcp-inform: invalid client IP: %s", client_ip);

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
@@ -74,7 +74,9 @@ static void pool_entry_destroy(pool_entry_t *entry)
 	}
 }
 
-/* Maximum CIDR string length: "xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx/128" = 43 chars */
+/* Maximum CIDR string length for IPv4: "255.255.255.255/32" = 18 chars.
+ * Note: DHCP option 121/249 (classless static routes) is IPv4-only.
+ * Using 43 to be safe with any reasonable input. */
 #define MAX_CIDR_LEN 43
 
 /**
@@ -310,8 +312,9 @@ static void load_pools(private_dhcp_inform_static_provider_t *this)
 			.prefix = prefix,
 		);
 
-		if (snprintf(routes_section, sizeof(routes_section),
-				 "pools.%s.routes", pool_name) >= (int)sizeof(routes_section))
+		int len = snprintf(routes_section, sizeof(routes_section),
+						   "pools.%s.routes", pool_name);
+		if (len < 0 || len >= (int)sizeof(routes_section))
 		{
 			DBG1(DBG_CFG, "dhcp-inform: pool name '%s' too long, skipping",
 				 pool_name);

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
@@ -83,6 +83,10 @@ static void pool_entry_destroy(pool_entry_t *entry)
  * Parse CIDR notation to traffic_selector.
  * Note: This function is intentionally duplicated in each provider file to keep
  * providers self-contained and independently compilable without shared utilities.
+ *
+ * Prefix 0 (/0, default route) is allowed here for admin flexibility.
+ * The TS provider filters out /0 routes since we don't want to push
+ * default routes extracted from traffic selectors.
  */
 static traffic_selector_t *parse_cidr(const char *cidr)
 {
@@ -137,7 +141,9 @@ static traffic_selector_t *parse_cidr(const char *cidr)
 }
 
 /**
- * Parse CIDR to host and prefix for pool matching
+ * Parse CIDR to host and prefix for pool matching.
+ * Prefix 0 (match-all) is allowed for admin flexibility.
+ * Note: Duplicated for self-contained compilation (see parse_cidr comment).
  */
 static bool parse_cidr_to_host(const char *cidr, host_t **host, uint8_t *prefix)
 {

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
@@ -405,8 +405,12 @@ METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
 		if (this->global_routes &&
 			this->global_routes->get_count(this->global_routes) > 0)
 		{
+			linked_list_t *routes;
+
 			DBG2(DBG_CFG, "dhcp-inform: returning global routes (no client IP)");
-			return clone_routes(this->global_routes);
+			routes = clone_routes(this->global_routes);
+			/* Return empty list on allocation failure */
+			return routes ? routes : linked_list_create();
 		}
 		return linked_list_create();
 	}
@@ -424,6 +428,8 @@ METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
 	{
 		if (ip_in_subnet(client, pool->network, pool->prefix))
 		{
+			linked_list_t *routes;
+
 			enumerator->destroy(enumerator);
 			client->destroy(client);
 
@@ -431,7 +437,9 @@ METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
 				 "returning %d pool-specific routes",
 				 client_ip, pool->name, pool->routes->get_count(pool->routes));
 
-			return clone_routes(pool->routes);
+			routes = clone_routes(pool->routes);
+			/* Return empty list on allocation failure */
+			return routes ? routes : linked_list_create();
 		}
 	}
 	enumerator->destroy(enumerator);
@@ -441,9 +449,13 @@ METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
 	if (this->global_routes &&
 		this->global_routes->get_count(this->global_routes) > 0)
 	{
+		linked_list_t *routes;
+
 		DBG1(DBG_CFG, "dhcp-inform: client %s using %d global routes",
 			 client_ip, this->global_routes->get_count(this->global_routes));
-		return clone_routes(this->global_routes);
+		routes = clone_routes(this->global_routes);
+		/* Return empty list on allocation failure */
+		return routes ? routes : linked_list_create();
 	}
 
 	DBG1(DBG_CFG, "dhcp-inform: no routes configured for client %s", client_ip);

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 Structured World Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ */
+
+/**
+ * @defgroup dhcp_inform_static_provider dhcp_inform_static_provider
+ * @{ @ingroup dhcp_inform
+ */
+
+#ifndef DHCP_INFORM_STATIC_PROVIDER_H_
+#define DHCP_INFORM_STATIC_PROVIDER_H_
+
+#include "dhcp_inform_provider.h"
+
+typedef struct dhcp_inform_static_provider_t dhcp_inform_static_provider_t;
+
+/**
+ * Static route provider - reads routes from strongswan.conf.
+ *
+ * Supports:
+ * - Global routes (apply to all clients)
+ * - Per-pool routes (override global for clients in specific CIDR)
+ *
+ * Configuration example:
+ *   charon.plugins.dhcp-inform.routes.route1 = 10.0.0.0/8
+ *   charon.plugins.dhcp-inform.pools.prod.cidr = 10.100.0.0/16
+ *   charon.plugins.dhcp-inform.pools.prod.routes.r1 = 192.168.1.0/24
+ */
+struct dhcp_inform_static_provider_t {
+
+	/**
+	 * Implements dhcp_inform_provider_t interface
+	 */
+	dhcp_inform_provider_t provider;
+};
+
+/**
+ * Create static route provider.
+ *
+ * @return				provider instance, NULL on failure
+ */
+dhcp_inform_static_provider_t *dhcp_inform_static_provider_create();
+
+#endif /** DHCP_INFORM_STATIC_PROVIDER_H_ @}*/

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
@@ -66,7 +66,8 @@ static bool is_valid_route_ts(traffic_selector_t *ts)
 }
 
 /**
- * Check if traffic selector already exists in list (deduplication)
+ * Check if traffic selector already exists in list (deduplication).
+ * Note: Duplicated for self-contained provider compilation.
  */
 static bool ts_exists_in_list(linked_list_t *list, traffic_selector_t *ts)
 {
@@ -103,6 +104,10 @@ static linked_list_t *extract_ts_from_ike_sa(const char *client_ip)
 	int route_count = 0;
 
 	routes = linked_list_create();
+	if (!routes)
+	{
+		return NULL;
+	}
 
 	if (!client_ip)
 	{

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
@@ -162,9 +162,17 @@ static linked_list_t *extract_ts_from_ike_sa(const char *client_ip)
 			ts_enum = child_sa->create_ts_enumerator(child_sa, FALSE);
 			while (ts_enum->enumerate(ts_enum, &ts))
 			{
+				traffic_selector_t *clone;
+
 				if (is_valid_route_ts(ts) && !ts_exists_in_list(routes, ts))
 				{
-					routes->insert_last(routes, ts->clone(ts));
+					clone = ts->clone(ts);
+					if (!clone)
+					{
+						DBG1(DBG_CFG, "dhcp-inform-ts: failed to clone TS");
+						continue;
+					}
+					routes->insert_last(routes, clone);
 					route_count++;
 					DBG2(DBG_CFG, "dhcp-inform-ts: extracted route %R", ts);
 				}

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2025 Structured World Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ */
+
+#include "dhcp_inform_ts_provider.h"
+
+#include <daemon.h>
+#include <collections/linked_list.h>
+#include <sa/ike_sa.h>
+#include <sa/child_sa.h>
+#include <selectors/traffic_selector.h>
+#include <networking/host.h>
+
+typedef struct private_dhcp_inform_ts_provider_t private_dhcp_inform_ts_provider_t;
+
+/**
+ * Private data
+ */
+struct private_dhcp_inform_ts_provider_t {
+
+	/**
+	 * Public interface
+	 */
+	dhcp_inform_ts_provider_t public;
+
+	/**
+	 * Whether TS routes are enabled
+	 */
+	bool enabled;
+};
+
+/**
+ * Check if a traffic selector is a valid route (not 0.0.0.0/0)
+ */
+static bool is_valid_route_ts(traffic_selector_t *ts)
+{
+	uint8_t mask;
+
+	if (ts->get_type(ts) != TS_IPV4_ADDR_RANGE)
+	{
+		/* Only handle IPv4 for DHCP option 121/249 */
+		return FALSE;
+	}
+
+	mask = ts->get_netmask(ts);
+
+	/* Skip default route (0.0.0.0/0) - we don't want to push that */
+	if (mask == 0)
+	{
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/**
+ * Check if traffic selector already exists in list (deduplication)
+ */
+static bool ts_exists_in_list(linked_list_t *list, traffic_selector_t *ts)
+{
+	enumerator_t *enumerator;
+	traffic_selector_t *existing;
+	bool found = FALSE;
+
+	enumerator = list->create_enumerator(list);
+	while (enumerator->enumerate(enumerator, &existing))
+	{
+		if (ts->equals(ts, existing))
+		{
+			found = TRUE;
+			break;
+		}
+	}
+	enumerator->destroy(enumerator);
+
+	return found;
+}
+
+/**
+ * Find IKE SA by virtual IP and extract traffic selectors
+ */
+static linked_list_t *extract_ts_from_ike_sa(const char *client_ip)
+{
+	linked_list_t *routes;
+	enumerator_t *ike_enum, *child_enum, *ts_enum;
+	ike_sa_t *ike_sa;
+	child_sa_t *child_sa;
+	traffic_selector_t *ts;
+	host_t *client_vip;
+	bool found_sa = FALSE;
+	int route_count = 0;
+
+	routes = linked_list_create();
+
+	if (!client_ip)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-ts: no client IP provided");
+		return routes;
+	}
+
+	client_vip = host_create_from_string(client_ip, 0);
+	if (!client_vip)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-ts: invalid client IP: %s", client_ip);
+		return routes;
+	}
+
+	/* Enumerate all IKE SAs to find one matching this client */
+	ike_enum = charon->ike_sa_manager->create_enumerator(
+										charon->ike_sa_manager, TRUE);
+
+	while (ike_enum->enumerate(ike_enum, &ike_sa))
+	{
+		enumerator_t *vip_enum;
+		host_t *vip;
+		bool match = FALSE;
+
+		/* Check if any virtual IP of this IKE SA matches our client */
+		vip_enum = ike_sa->create_virtual_ip_enumerator(ike_sa, FALSE);
+		while (vip_enum->enumerate(vip_enum, &vip))
+		{
+			if (vip->ip_equals(vip, client_vip))
+			{
+				match = TRUE;
+				break;
+			}
+		}
+		vip_enum->destroy(vip_enum);
+
+		if (!match)
+		{
+			continue;
+		}
+
+		found_sa = TRUE;
+		DBG1(DBG_CFG, "dhcp-inform-ts: found IKE SA for client %s", client_ip);
+
+		/* Enumerate CHILD SAs and extract remote traffic selectors */
+		child_enum = ike_sa->create_child_sa_enumerator(ike_sa);
+		while (child_enum->enumerate(child_enum, &child_sa))
+		{
+			/* Get remote (server-side) traffic selectors - these are the
+			 * networks the client should be able to reach */
+			ts_enum = child_sa->create_ts_enumerator(child_sa, FALSE);
+			while (ts_enum->enumerate(ts_enum, &ts))
+			{
+				if (is_valid_route_ts(ts) && !ts_exists_in_list(routes, ts))
+				{
+					routes->insert_last(routes, ts->clone(ts));
+					route_count++;
+					DBG2(DBG_CFG, "dhcp-inform-ts: extracted route %R", ts);
+				}
+			}
+			ts_enum->destroy(ts_enum);
+		}
+		child_enum->destroy(child_enum);
+
+		/* Found the SA, no need to continue */
+		break;
+	}
+	ike_enum->destroy(ike_enum);
+	client_vip->destroy(client_vip);
+
+	if (!found_sa)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-ts: no IKE SA found for client %s",
+			 client_ip);
+	}
+	else
+	{
+		DBG1(DBG_CFG, "dhcp-inform-ts: extracted %d routes for client %s",
+			 route_count, client_ip);
+	}
+
+	return routes;
+}
+
+METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
+	private_dhcp_inform_ts_provider_t *this, const char *client_ip)
+{
+	if (!this->enabled)
+	{
+		return linked_list_create();
+	}
+
+	return extract_ts_from_ike_sa(client_ip);
+}
+
+METHOD(dhcp_inform_provider_t, get_name, const char*,
+	private_dhcp_inform_ts_provider_t *this)
+{
+	return "traffic-selectors";
+}
+
+METHOD(dhcp_inform_provider_t, is_available, bool,
+	private_dhcp_inform_ts_provider_t *this)
+{
+	return this->enabled;
+}
+
+METHOD(dhcp_inform_provider_t, destroy, void,
+	private_dhcp_inform_ts_provider_t *this)
+{
+	free(this);
+}
+
+/**
+ * See header
+ */
+dhcp_inform_ts_provider_t *dhcp_inform_ts_provider_create()
+{
+	private_dhcp_inform_ts_provider_t *this;
+
+	INIT(this,
+		.public = {
+			.provider = {
+				.get_routes = _get_routes,
+				.get_name = _get_name,
+				.is_available = _is_available,
+				.destroy = _destroy,
+			},
+		},
+		.enabled = lib->settings->get_bool(lib->settings,
+			"%s.plugins.dhcp-inform.use_ts_routes", FALSE, lib->ns),
+	);
+
+	if (this->enabled)
+	{
+		DBG1(DBG_CFG, "dhcp-inform: TS route provider enabled (EXCLUSIVE mode)");
+	}
+	else
+	{
+		DBG2(DBG_CFG, "dhcp-inform: TS route provider disabled");
+	}
+
+	return &this->public;
+}

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
@@ -204,12 +204,21 @@ static linked_list_t *extract_ts_from_ike_sa(const char *client_ip)
 METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
 	private_dhcp_inform_ts_provider_t *this, const char *client_ip)
 {
+	linked_list_t *routes;
+
 	if (!this->enabled)
 	{
+		/* Provider disabled - return empty list (may be NULL on OOM) */
 		return linked_list_create();
 	}
 
-	return extract_ts_from_ike_sa(client_ip);
+	routes = extract_ts_from_ike_sa(client_ip);
+	if (!routes)
+	{
+		/* Allocation failed - return empty list as fallback (may be NULL on OOM) */
+		return linked_list_create();
+	}
+	return routes;
 }
 
 METHOD(dhcp_inform_provider_t, get_name, const char*,

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
@@ -119,6 +119,7 @@ static linked_list_t *extract_ts_from_ike_sa(const char *client_ip)
 	if (!client_vip)
 	{
 		DBG1(DBG_CFG, "dhcp-inform-ts: invalid client IP: %s", client_ip);
+		/* Return empty list - caller handles empty routes gracefully */
 		return routes;
 	}
 

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 Structured World Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ */
+
+/**
+ * @defgroup dhcp_inform_ts_provider dhcp_inform_ts_provider
+ * @{ @ingroup dhcp_inform
+ */
+
+#ifndef DHCP_INFORM_TS_PROVIDER_H_
+#define DHCP_INFORM_TS_PROVIDER_H_
+
+#include "dhcp_inform_provider.h"
+
+typedef struct dhcp_inform_ts_provider_t dhcp_inform_ts_provider_t;
+
+/**
+ * Traffic Selector route provider - extracts routes from IKE SA.
+ *
+ * This provider is EXCLUSIVE - when enabled, it's the only source of routes.
+ * Designed for Windows 7 compatibility where clients don't properly handle
+ * traffic selectors pushed via IKE.
+ *
+ * Behavior:
+ * - Finds IKE SA by matching client virtual IP
+ * - Extracts remote traffic selectors from all CHILD_SAs
+ * - Converts traffic selectors to routes for DHCP Option 121/249
+ */
+struct dhcp_inform_ts_provider_t {
+
+	/**
+	 * Implements dhcp_inform_provider_t interface
+	 */
+	dhcp_inform_provider_t provider;
+};
+
+/**
+ * Create TS route provider.
+ *
+ * @return				provider instance, NULL on failure
+ */
+dhcp_inform_ts_provider_t *dhcp_inform_ts_provider_create();
+
+#endif /** DHCP_INFORM_TS_PROVIDER_H_ @}*/


### PR DESCRIPTION
## Summary
- Add provider architecture for flexible route sources in dhcp-inform plugin
- Support THREE mutually exclusive route modes

## Test plan
- [ ] Build and test all modes