### PR TITLE
ci(packages): drop fc39/fc40, add fc43, add native arm64 builds

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -104,6 +104,21 @@ jobs:
             libssl: libssl3
             libldap: libldap-2.5-0
             arch: amd64
+          - os: ubuntu-24.04-arm
+            dist: noble
+            libssl: libssl3t64
+            libldap: libldap-2.5-0
+            arch: arm64
+          - os: ubuntu-22.04-arm
+            dist: jammy
+            libssl: libssl3
+            libldap: libldap-2.5-0
+            arch: arm64
+          - os: ubuntu-22.04-arm
+            dist: bookworm
+            libssl: libssl3
+            libldap: libldap-2.5-0
+            arch: arm64
 
     runs-on: ${{ matrix.os }}
 
@@ -376,16 +391,32 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - fedora: 39
-            container: fedora:39
-          - fedora: 40
-            container: fedora:40
           - fedora: 41
             container: fedora:41
+            runs-on: ubuntu-latest
+            arch: x86_64
           - fedora: 42
             container: fedora:42
+            runs-on: ubuntu-latest
+            arch: x86_64
+          - fedora: 43
+            container: fedora:43
+            runs-on: ubuntu-latest
+            arch: x86_64
+          - fedora: 41
+            container: fedora:41
+            runs-on: ubuntu-24.04-arm
+            arch: aarch64
+          - fedora: 42
+            container: fedora:42
+            runs-on: ubuntu-24.04-arm
+            arch: aarch64
+          - fedora: 43
+            container: fedora:43
+            runs-on: ubuntu-24.04-arm
+            arch: aarch64
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     container: ${{ matrix.container }}
 
     steps:
@@ -578,15 +609,15 @@ jobs:
       - name: Upload RPM artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: rpm-fc${{ matrix.fedora }}
+          name: rpm-fc${{ matrix.fedora }}-${{ matrix.arch }}
           path: "rpms/*.rpm"
           retention-days: 7
 
-      # Upload SRPM only from fc42 job to avoid duplicates (SRPMs are identical across distros)
-      # If fc42 build fails, SRPMs won't be uploaded - this is acceptable as binary
+      # Upload SRPM only from fc43 x86_64 job to avoid duplicates (SRPMs are arch-independent)
+      # If fc43 build fails, SRPMs won't be uploaded - this is acceptable as binary
       # RPMs are the primary deliverable and SRPMs can be regenerated from git
       - name: Upload SRPM artifacts
-        if: matrix.fedora == 42
+        if: matrix.fedora == 43 && matrix.arch == 'x86_64'
         uses: actions/upload-artifact@v4
         with:
           name: srpm
@@ -631,7 +662,8 @@ jobs:
         run: |
           # Keep these in sync with structured-world/repo/.github/workflows/publish.yml
           PUBLISH_WORKFLOW_NAME="Publish Repo"
-          RUN_MATCH="Publish Repo (strongswan ${{ github.run_id }})"
+          # Match by run_id embedded in title — works regardless of other fields in run-name.
+          RUN_ID_FRAGMENT="strongswan ${{ github.run_id }}"
           START_TIMEOUT_SECONDS=600 # 10 minutes
           START_POLL_INTERVAL=10
           START_MAX_ATTEMPTS=$((START_TIMEOUT_SECONDS / START_POLL_INTERVAL))
@@ -639,7 +671,7 @@ jobs:
           for ((i=1; i<=START_MAX_ATTEMPTS; i++)); do
             echo "Waiting for Publish Repo to start (attempt ${i}/${START_MAX_ATTEMPTS})..."
             RUN_IDS=$(gh run list -R structured-world/repo -w "$PUBLISH_WORKFLOW_NAME" --json databaseId,createdAt,event,displayTitle \
-              --jq "[.[] | select(.event == \"workflow_dispatch\" and .displayTitle == \"${RUN_MATCH}\") | {id: .databaseId, createdAt: .createdAt}] | sort_by(.createdAt) | reverse | .[0].id // empty") || {
+              --jq "[.[] | select(.event == \"workflow_dispatch\" and (.displayTitle | contains(\"${RUN_ID_FRAGMENT}\"))) | {id: .databaseId, createdAt: .createdAt}] | sort_by(.createdAt) | reverse | .[0].id // empty") || {
               echo "Error: gh run list failed while waiting for Publish Repo workflow" >&2
               exit 1
             }

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -403,6 +403,7 @@ jobs:
             container: fedora:43
             runs-on: ubuntu-latest
             arch: x86_64
+            upload_srpm: true
           - fedora: 41
             container: fedora:41
             runs-on: ubuntu-24.04-arm
@@ -613,11 +614,11 @@ jobs:
           path: "rpms/*.rpm"
           retention-days: 7
 
-      # Upload SRPM only from fc43 x86_64 job to avoid duplicates (SRPMs are arch-independent)
-      # If fc43 build fails, SRPMs won't be uploaded - this is acceptable as binary
-      # RPMs are the primary deliverable and SRPMs can be regenerated from git
+      # Upload SRPM only from the matrix row flagged with upload_srpm: true (fc43 x86_64).
+      # Using a matrix flag keeps the selection policy in one place — future Fedora
+      # rollovers only need a matrix change, not a separate condition update.
       - name: Upload SRPM artifacts
-        if: matrix.fedora == 43 && matrix.arch == 'x86_64'
+        if: matrix.upload_srpm == true
         uses: actions/upload-artifact@v4
         with:
           name: srpm
@@ -663,7 +664,8 @@ jobs:
           # Keep these in sync with structured-world/repo/.github/workflows/publish.yml
           PUBLISH_WORKFLOW_NAME="Publish Repo"
           # Match by run_id embedded in title — works regardless of other fields in run-name.
-          RUN_ID_FRAGMENT="strongswan ${{ github.run_id }}"
+          # Use word-boundary anchors ([^0-9] or start/end) so run_id 123 never matches 1234.
+          RUN_ID_PATTERN="(^|[^0-9])strongswan ${{ github.run_id }}([^0-9]|$)"
           START_TIMEOUT_SECONDS=600 # 10 minutes
           START_POLL_INTERVAL=10
           START_MAX_ATTEMPTS=$((START_TIMEOUT_SECONDS / START_POLL_INTERVAL))
@@ -671,7 +673,7 @@ jobs:
           for ((i=1; i<=START_MAX_ATTEMPTS; i++)); do
             echo "Waiting for Publish Repo to start (attempt ${i}/${START_MAX_ATTEMPTS})..."
             RUN_IDS=$(gh run list -R structured-world/repo -w "$PUBLISH_WORKFLOW_NAME" --json databaseId,createdAt,event,displayTitle \
-              --jq "[.[] | select(.event == \"workflow_dispatch\" and (.displayTitle | contains(\"${RUN_ID_FRAGMENT}\"))) | {id: .databaseId, createdAt: .createdAt}] | sort_by(.createdAt) | reverse | .[0].id // empty") || {
+              --jq "[.[] | select(.event == \"workflow_dispatch\" and (.displayTitle | test(\"${RUN_ID_PATTERN}\"))) | {id: .databaseId, createdAt: .createdAt}] | sort_by(.createdAt) | reverse | .[0].id // empty") || {
               echo "Error: gh run list failed while waiting for Publish Repo workflow" >&2
               exit 1
             }

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -62,7 +62,7 @@ jobs:
     needs: check-reviews
     runs-on: ubuntu-latest
     container:
-      image: fedora:42
+      image: fedora:43
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Remove Fedora 39 and 40 from RPM build matrix
- Add Fedora 43
- Add native **aarch64** RPM builds via `ubuntu-24.04-arm` runners with Fedora container
- Add native **arm64** DEB builds via `ubuntu-24.04-arm` (noble) and `ubuntu-22.04-arm` (jammy, bookworm)
- RPM artifact name: `rpm-fc{version}-{arch}` to disambiguate x86_64 vs aarch64
- SRPM uploaded only from fc43/x86_64 (arch-independent)
- `wait-for-publish` step: `contains()` match on run title (resilient to run-name format changes)

Closes #120