### PR TITLE
fix(systemd): add ExecStop, ExecReload --load-creds, ExecStartPost

### DIFF
--- a/init/systemd-starter/strongswan-starter.service.in
+++ b/init/systemd-starter/strongswan-starter.service.in
@@ -4,8 +4,15 @@ After=syslog.target network-online.target
 Wants=syslog.target network-online.target
 
 [Service]
+Type=simple
 ExecStart=@SBINDIR@/@IPSEC_SCRIPT@ start --nofork
+ExecStop=@SBINDIR@/@IPSEC_SCRIPT@ stop
+ExecReload=@SBINDIR@/@IPSEC_SCRIPT@ reload
+ExecReload=@SBINDIR@/swanctl --load-creds
+ExecStartPost=/bin/sleep 2
+ExecStartPost=@SBINDIR@/swanctl --load-creds
 Restart=on-abnormal
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Fixes missing `ExecStop`, `ExecReload=swanctl --load-creds`, `ExecStartPost=swanctl --load-creds` in `strongswan-starter.service.in`
- Without `--load-creds` after start/reload, TLS certs aren't loaded into charon → IKEv2 road-warrior auth fails

## Changes
- `ExecStop` — clean shutdown
- `ExecReload` (second) — `swanctl --load-creds` on `systemctl reload` for certbot hooks
- `ExecStartPost` — sleep 2 + `swanctl --load-creds` after startup
- `Type=simple` explicit, `RestartSec=5`

## Testing
Verified on Ubuntu 24.04 (strongswan-lantec): IKEv2 road-warrior connects after restart without manual intervention.

## Risks
- `sleep 2` adds 2s to service start time — acceptable, charon needs time to initialize before swanctl can connect

Closes #19