### PR TITLE
fix(ci): use libldap2 dependency for noble packages

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -92,7 +92,8 @@ jobs:
           - os: ubuntu-24.04
             dist: noble
             libssl: libssl3t64
-            libldap: libldap-2.5-0
+            # noble ships OpenLDAP 2.6 as libldap2; libldap-2.5-0 does not exist there
+            libldap: libldap2
             arch: amd64
           - os: ubuntu-22.04
             dist: jammy
@@ -107,7 +108,8 @@ jobs:
           - os: ubuntu-24.04-arm
             dist: noble
             libssl: libssl3t64
-            libldap: libldap-2.5-0
+            # noble ships OpenLDAP 2.6 as libldap2; libldap-2.5-0 does not exist there
+            libldap: libldap2
             arch: arm64
           - os: ubuntu-22.04-arm
             dist: jammy


### PR DESCRIPTION
## Summary

Every strongswan-sw package built for noble (Ubuntu 24.04) declared `Depends: libldap-2.5-0`, which does not exist in noble (OpenLDAP 2.6 ships as `libldap2`). Installation failed on every noble host:

```
strongswan-sw : Depends: libldap-2.5-0 but it is not installable
```

Reproduced verbatim with the documented install flow from repo.sw.foundation in a clean ubuntu:24.04 amd64 container. The noble binaries are built on ubuntu-24.04 against libldap2-dev and link `libldap.so.2` (verified with ldd on the built plugin), so `libldap2` is also the factually correct runtime dependency.

## Changes

- build-deb matrix: `libldap: libldap2` for both noble rows (amd64, arm64); jammy and bookworm keep `libldap-2.5-0`

## Testing

- Full 6.0.7 build in a clean ubuntu:24.04 container with the same configure flags as this workflow: build OK, pgsql and dhcp-inform plugins built
- .deb assembled with the corrected dependency installs cleanly on real noble (`Setting up strongswan-sw (6.0.7-sw.1)`)

Related: the repo-side index fixes live in structured-world/repo#26; both are needed before noble installs work end to end.

Closes #22