### PR TITLE
fix(ci): push upstream sync with app token that has workflows permission

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -66,11 +66,26 @@ jobs:
       rebase_success: ${{ steps.sync.outputs.rebase_success }}
 
     steps:
+      # Push master/sw with a releaser app token: upstream releases routinely
+      # change .github/workflows/*, and the default GITHUB_TOKEN has no
+      # `workflows` permission, so mirroring them is rejected by GitHub
+      # ("refusing to allow a GitHub App to create or update workflow").
+      - name: Generate release bot token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+          owner: structured-world
+          repositories: strongswan
+          permission-contents: write
+          permission-workflows: write
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary

The daily sync-upstream workflow has been failing since at least 2026-06-17 and was then disabled by GitHub for inactivity, so upstream 6.0.7 (2026-06-08) was never synced (done manually in #21).

Root cause: the sync job pushes master (mirror of the upstream release) with the default GITHUB_TOKEN. Upstream releases routinely change `.github/workflows/*`, and GITHUB_TOKEN has no `workflows` permission:

```
! [remote rejected] master -> master (refusing to allow a GitHub App to create
or update workflow .github/workflows/android.yml without workflows permission)
```

## Changes

- Mint a releaser app token (same app as build-packages.yml) with `permission-contents: write` and `permission-workflows: write`, use it for checkout so pushes of master/sw carry it

## Post-merge actions (manual)

1. Grant the releaser GitHub App the **Workflows** repository permission in app settings (token minting fails otherwise)
2. Re-enable the workflow: `gh workflow enable sync-upstream.yml -R structured-world/strongswan`
3. Optionally verify with a workflow_dispatch run

## Testing

Not runnable outside Actions; the failure mode and token requirements are taken from the rejected push in run logs (2026-06-24).

Closes #23