### PR TITLE
fix(ci): push upstream release tag to fork during sync

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -108,6 +108,11 @@ jobs:
           git checkout -B master origin/master
           git reset --hard "$UPSTREAM_TAG"
           git push origin master --force
+          # Push the upstream release tag too: build-packages.yml derives the
+          # sw.N revision by counting PR merges since this tag. Without it in
+          # the fork every build computes sw.1 and publish silently drops the
+          # rebuilt packages as pool duplicates.
+          git push origin "refs/tags/${UPSTREAM_TAG}"
 
           # Rebase sw branch onto the release
           git checkout sw


### PR DESCRIPTION
## Summary

sync-upstream mirrors the upstream release into master and rebases sw, but never pushes the upstream tag itself: 6.0.5, 6.0.6 and 6.0.7 were all absent from the fork. build-packages.yml derives the sw.N revision by counting merge commits newer than the upstream tag, so with the tag missing every build silently computed sw.1, and the publish script's `cp -n` then dropped rebuilt 6.0.x-sw.1 packages as pool duplicates.

6.0.7 was pushed to the fork manually today; this makes it automatic for the next upstream release.

## Changes

- Push `refs/tags/${UPSTREAM_TAG}` to origin right after force-pushing master in the sync job

## Testing

- Manual equivalent verified today: after pushing the 6.0.7 tag, the queued builds compute sw.15/sw.16 instead of colliding at sw.1

Closes #26