### PR TITLE
fix(sql): emit PostgreSQL-compatible statements in sql_logger

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,6 @@
 /src/libstrongswan/database/ @polaz
 /src/libcharon/plugins/sql/ @polaz
 /src/libcharon/plugins/dhcp_inform/ @polaz
+/src/pool/ @polaz
 /.github/workflows/build-packages.yml @polaz
 /.github/workflows/sync-upstream.yml @polaz

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,7 @@
 # All changes to sw-specific code require review
 /src/libstrongswan/plugins/pgsql/ @polaz
 /src/libstrongswan/database/ @polaz
+/src/libcharon/plugins/sql/ @polaz
+/src/libcharon/plugins/dhcp_inform/ @polaz
 /.github/workflows/build-packages.yml @polaz
 /.github/workflows/sync-upstream.yml @polaz

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,6 +25,11 @@ This is the **Structured World Foundation fork** of strongSwan. The `sw` branch 
      uses INSERT ... ON CONFLICT and double-quoted identifiers, MySQL/SQLite
      keep REPLACE INTO and backtick quoting
 
+5. **PostgreSQL support in pool tooling** (`src/pool/`)
+   - `postgresql.sql`: reference schema alongside mysql.sql/sqlite.sql
+   - `pool.c`: pools.end column double-quoted for PostgreSQL (END is a
+     reserved word there); other backends keep the unquoted statements
+
 ## Upstream Code Style (IMPORTANT)
 
 strongSwan uses **mixed C89/C99 style**. The codebase is not strictly C89 — many files use C99 features. Our plugin follows patterns found in similar upstream plugins.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,11 @@ This is the **Structured World Foundation fork** of strongSwan. The `sw` branch 
    - `src/libstrongswan/database/database.h`: DB_PGSQL enum
    - `src/libstrongswan/database/database.c`: "PostgreSQL" in ENUM names
 
+4. **SQL dialect support in the sql plugin** (`src/libcharon/plugins/sql/`)
+   - `sql_logger.c`: statements selected per database driver; PostgreSQL
+     uses INSERT ... ON CONFLICT and double-quoted identifiers, MySQL/SQLite
+     keep REPLACE INTO and backtick quoting
+
 ## Upstream Code Style (IMPORTANT)
 
 strongSwan uses **mixed C89/C99 style**. The codebase is not strictly C89 — many files use C99 features. Our plugin follows patterns found in similar upstream plugins.

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -271,6 +271,16 @@ jobs:
             cp -a "$PGSQL_CONF" "${PGSQL_PKGDIR}/etc/strongswan.d/charon/"
             rm -f "$PGSQL_CONF"
           fi
+          # The PostgreSQL reference schema ships with the plugin package:
+          # strongswan-pgsql also installs on stock strongswan, which does
+          # not carry this template. Moved (not copied) so the two packages
+          # never ship the same path.
+          PGSQL_SCHEMA="${PKGDIR}/usr/share/strongswan/templates/database/sql/postgresql.sql"
+          if [ -f "$PGSQL_SCHEMA" ]; then
+            mkdir -p "${PGSQL_PKGDIR}/usr/share/strongswan/templates/database/sql"
+            cp -a "$PGSQL_SCHEMA" "${PGSQL_PKGDIR}/usr/share/strongswan/templates/database/sql/"
+            rm -f "$PGSQL_SCHEMA"
+          fi
 
           printf '%s\n' \
             "Package: strongswan-pgsql" \

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -288,13 +288,15 @@ jobs:
             "Section: net" \
             "Priority: optional" \
             "Architecture: ${ARCH}" \
-            "Depends: strongswan (>= 6.0) | strongswan-sw, libpq5" \
+            "Depends: strongswan-sw (= ${VERSION}), libpq5" \
             "Maintainer: Structured World Foundation <dev@sw.foundation>" \
             "Homepage: https://github.com/structured-world/strongswan" \
             "Description: PostgreSQL plugin for strongSwan" \
             " PostgreSQL database backend for strongSwan SQL plugin." \
             " Enables storing VPN user credentials and configuration in PostgreSQL." \
-            " Works with system strongswan (>= 6.0) or strongswan-sw." \
+            " Requires the strongswan-sw base package of the same build: the" \
+            " plugin is ABI-coupled to it, and the dialect-aware sql plugin" \
+            " that emits PostgreSQL statements ships there." \
             > "${PGSQL_PKGDIR}/DEBIAN/control"
 
           fakeroot dpkg-deb --build "${PGSQL_PKGDIR}"
@@ -334,13 +336,14 @@ jobs:
             "Section: net" \
             "Priority: optional" \
             "Architecture: ${ARCH}" \
-            "Depends: strongswan (>= 6.0) | strongswan-sw, strongswan-pgsql" \
+            "Depends: strongswan-sw (= ${VERSION}), strongswan-pgsql (= ${VERSION})" \
             "Maintainer: Structured World Foundation <dev@sw.foundation>" \
             "Homepage: https://github.com/structured-world/strongswan" \
             "Description: DHCP INFORM responder plugin for strongSwan" \
             " Responds to Windows DHCPINFORM requests with split-tunnel routes" \
             " from PostgreSQL database. Delivers routes via DHCP option 121/249." \
-            " Works with system strongswan (>= 6.0) or strongswan-sw." \
+            " Requires the strongswan-sw base package of the same build (the" \
+            " plugin is ABI-coupled to it) and strongswan-pgsql." \
             > "${DHCP_INFORM_PKGDIR}/DEBIAN/control"
 
           if [ -n "$DHCP_INFORM_SO" ]; then

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,7 @@ jobs:
               - 'src/libstrongswan/networking/streams/stream_service_unix.c'
               - 'src/libcharon/plugins/dhcp_inform/**'
               - 'src/libcharon/plugins/sql/**'
+              - 'src/pool/**'
               - 'configure.ac'
       - name: Report status
         run: |
@@ -77,6 +78,7 @@ jobs:
             - src/libstrongswan/networking/streams/stream_service_unix.c
             - src/libcharon/plugins/dhcp_inform
             - src/libcharon/plugins/sql
+            - src/pool
           query-filters:
             - exclude:
                 id: cpp/fixme-comment

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -99,12 +99,14 @@ jobs:
         ./configure \
           --enable-pgsql \
           --enable-sql \
+          --enable-attr-sql \
           --enable-vici \
           --enable-systemd \
           --enable-openssl \
           --enable-dhcp-inform
         # Build libstrongswan, libcharon and pool (contain our changes);
-        # src/pool is built when sql or attr-sql is enabled
+        # the pool binary itself is gated on --enable-attr-sql (USE_ATTR_SQL
+        # in src/pool/Makefile.am), --enable-sql alone only ships templates
         make -C src/libstrongswan -j$(nproc)
         make -C src/libcharon -j$(nproc)
         make -C src/pool -j$(nproc)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,7 @@ jobs:
               - 'src/libstrongswan/database/**'
               - 'src/libstrongswan/networking/streams/stream_service_unix.c'
               - 'src/libcharon/plugins/dhcp_inform/**'
+              - 'src/libcharon/plugins/sql/**'
               - 'configure.ac'
       - name: Report status
         run: |
@@ -75,6 +76,7 @@ jobs:
             - src/libstrongswan/database
             - src/libstrongswan/networking/streams/stream_service_unix.c
             - src/libcharon/plugins/dhcp_inform
+            - src/libcharon/plugins/sql
           query-filters:
             - exclude:
                 id: cpp/fixme-comment

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -103,9 +103,11 @@ jobs:
           --enable-systemd \
           --enable-openssl \
           --enable-dhcp-inform
-        # Build libstrongswan and libcharon (contain our changes)
+        # Build libstrongswan, libcharon and pool (contain our changes);
+        # src/pool is built when sql or attr-sql is enabled
         make -C src/libstrongswan -j$(nproc)
         make -C src/libcharon -j$(nproc)
+        make -C src/pool -j$(nproc)
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/src/libcharon/plugins/sql/sql_logger.c
+++ b/src/libcharon/plugins/sql/sql_logger.c
@@ -151,7 +151,10 @@ sql_logger_t *sql_logger_create(database_t *db)
 
 	/* REPLACE INTO and backtick quoting are MySQL/SQLite dialect; PostgreSQL
 	 * needs ON CONFLICT (on the ike_sas primary key, local_spi) and
-	 * double-quoted identifiers instead */
+	 * double-quoted identifiers instead. Like the MySQL/SQLite statements,
+	 * the upsert does not reference the optional lastuse accounting column:
+	 * the postgresql.sql reference schema refreshes it with an UPDATE
+	 * trigger, mirroring MySQL's ON UPDATE CURRENT_TIMESTAMP. */
 	if (db->get_driver(db) == DB_PGSQL)
 	{
 		this->insert_sa = "INSERT INTO ike_sas ("

--- a/src/libcharon/plugins/sql/sql_logger.c
+++ b/src/libcharon/plugins/sql/sql_logger.c
@@ -44,6 +44,16 @@ struct private_sql_logger_t {
 	int level;
 
 	/**
+	 * ike_sas upsert statement in the backend's SQL dialect
+	 */
+	char *insert_sa;
+
+	/**
+	 * logs insert statement in the backend's SQL dialect
+	 */
+	char *insert_log;
+
+	/**
 	 * avoid recursive calls by the same thread
 	 */
 	thread_value_t *recursive;
@@ -86,12 +96,7 @@ METHOD(logger_t, log_, void,
 		local_host = ike_sa->get_my_host(ike_sa);
 		remote_host = ike_sa->get_other_host(ike_sa);
 
-		this->db->execute(this->db, NULL, "REPLACE INTO ike_sas ("
-						  "local_spi, remote_spi, id, initiator, "
-						  "local_id_type, local_id_data, "
-						  "remote_id_type, remote_id_data, "
-						  "host_family, local_host_data, remote_host_data) "
-						  "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		this->db->execute(this->db, NULL, this->insert_sa,
 						  DB_BLOB, local_spi, DB_BLOB, remote_spi,
 						  DB_INT, ike_sa->get_unique_id(ike_sa),
 						  DB_INT, id->is_initiator(id),
@@ -102,9 +107,7 @@ METHOD(logger_t, log_, void,
 						  DB_INT, local_host->get_family(local_host),
 						  DB_BLOB, local_host->get_address(local_host),
 						  DB_BLOB, remote_host->get_address(remote_host));
-		this->db->execute(this->db, NULL, "INSERT INTO logs ("
-						  "local_spi, `signal`, level, msg) "
-						  "VALUES (?, ?, ?, ?)",
+		this->db->execute(this->db, NULL, this->insert_log,
 						  DB_BLOB, local_spi, DB_INT, group, DB_INT, level,
 						  DB_TEXT, message);
 	}
@@ -145,6 +148,45 @@ sql_logger_t *sql_logger_create(database_t *db)
 		.level = lib->settings->get_int(lib->settings,
 										"%s.plugins.sql.loglevel", -1, lib->ns),
 	);
+
+	/* REPLACE INTO and backtick quoting are MySQL/SQLite dialect; PostgreSQL
+	 * needs ON CONFLICT (on the ike_sas primary key, local_spi) and
+	 * double-quoted identifiers instead */
+	if (db->get_driver(db) == DB_PGSQL)
+	{
+		this->insert_sa = "INSERT INTO ike_sas ("
+						  "local_spi, remote_spi, id, initiator, "
+						  "local_id_type, local_id_data, "
+						  "remote_id_type, remote_id_data, "
+						  "host_family, local_host_data, remote_host_data) "
+						  "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+						  "ON CONFLICT (local_spi) DO UPDATE SET "
+						  "remote_spi = EXCLUDED.remote_spi, "
+						  "id = EXCLUDED.id, "
+						  "initiator = EXCLUDED.initiator, "
+						  "local_id_type = EXCLUDED.local_id_type, "
+						  "local_id_data = EXCLUDED.local_id_data, "
+						  "remote_id_type = EXCLUDED.remote_id_type, "
+						  "remote_id_data = EXCLUDED.remote_id_data, "
+						  "host_family = EXCLUDED.host_family, "
+						  "local_host_data = EXCLUDED.local_host_data, "
+						  "remote_host_data = EXCLUDED.remote_host_data";
+		this->insert_log = "INSERT INTO logs ("
+						   "local_spi, \"signal\", level, msg) "
+						   "VALUES (?, ?, ?, ?)";
+	}
+	else
+	{
+		this->insert_sa = "REPLACE INTO ike_sas ("
+						  "local_spi, remote_spi, id, initiator, "
+						  "local_id_type, local_id_data, "
+						  "remote_id_type, remote_id_data, "
+						  "host_family, local_host_data, remote_host_data) "
+						  "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+		this->insert_log = "INSERT INTO logs ("
+						   "local_spi, `signal`, level, msg) "
+						   "VALUES (?, ?, ?, ?)";
+	}
 
 	return &this->public;
 }

--- a/src/pool/Makefile.am
+++ b/src/pool/Makefile.am
@@ -20,4 +20,4 @@ pool_LDADD = \
 endif USE_ATTR_SQL
 
 templatesdir = $(pkgdatadir)/templates/database/sql
-dist_templates_DATA = mysql.sql sqlite.sql
+dist_templates_DATA = mysql.sql sqlite.sql postgresql.sql

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -758,8 +758,10 @@ static enumerator_t *create_lease_query(char *filter, array_t **to_free)
 				DB_INT, !addr_chunk.ptr,
 					DB_BLOB, addr_chunk,
 				DB_INT, tstamp == 0, DB_UINT, tstamp, DB_UINT, tstamp,
-				DB_INT, !valid, DB_INT, time(NULL),
-				DB_INT, !expired, DB_INT, time(NULL),
+				/* bind current time unsigned like every other timestamp
+				 * operand, signed int truncates past 2038 */
+				DB_INT, !valid, DB_UINT, time(NULL),
+				DB_INT, !expired, DB_UINT, time(NULL),
 				DB_INT, !online,
 				/* union */
 				DB_INT, !(valid || expired),

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -77,8 +77,14 @@ static u_int create_pool(char *name, chunk_t start, chunk_t end, u_int timeout)
 		}
 		del(name);
 	}
+	/* END is a reserved word in PostgreSQL, the pools.end column must be
+	 * double-quoted there; other backends take it unquoted */
 	if (db->execute(db, &pool,
-			"INSERT INTO pools (name, start, end, timeout) VALUES (?, ?, ?, ?)",
+			db->get_driver(db) == DB_PGSQL ?
+				"INSERT INTO pools (name, start, \"end\", timeout) "
+				"VALUES (?, ?, ?, ?)" :
+				"INSERT INTO pools (name, start, end, timeout) "
+				"VALUES (?, ?, ?, ?)",
 			DB_TEXT, name, DB_BLOB, start, DB_BLOB, end,
 			DB_UINT, timeout) != 1)
 	{
@@ -230,7 +236,10 @@ static void status(void)
 	}
 	found = FALSE;
 
-	pool = db->query(db, "SELECT id, name, start, end, timeout FROM pools",
+	pool = db->query(db,
+					 db->get_driver(db) == DB_PGSQL ?
+						"SELECT id, name, start, \"end\", timeout FROM pools" :
+						"SELECT id, name, start, end, timeout FROM pools",
 					 DB_INT, DB_TEXT, DB_BLOB, DB_BLOB, DB_UINT);
 	if (pool)
 	{
@@ -478,7 +487,9 @@ static void add_addresses(char *pool, char *path, u_int timeout)
 	{	/* update address family if necessary */
 		addr = host_create_from_string("%any6", 0);
 		if (db->execute(db, NULL,
-					"UPDATE pools SET start = ?, end = ? WHERE id = ?",
+					db->get_driver(db) == DB_PGSQL ?
+						"UPDATE pools SET start = ?, \"end\" = ? WHERE id = ?" :
+						"UPDATE pools SET start = ?, end = ? WHERE id = ?",
 					DB_BLOB, addr->get_address(addr),
 					DB_BLOB, addr->get_address(addr), DB_UINT, pool_id) <= 0)
 		{
@@ -546,7 +557,10 @@ static void resize(char *name, host_t *end)
 
 	new_addr = end->get_address(end);
 
-	query = db->query(db, "SELECT id, end FROM pools WHERE name = ?",
+	query = db->query(db,
+					  db->get_driver(db) == DB_PGSQL ?
+						"SELECT id, \"end\" FROM pools WHERE name = ?" :
+						"SELECT id, end FROM pools WHERE name = ?",
 					  DB_TEXT, name, DB_UINT, DB_BLOB);
 	if (!query || !query->enumerate(query, &id, &old_addr))
 	{
@@ -577,7 +591,9 @@ static void resize(char *name, host_t *end)
 
 	db->transaction(db, FALSE);
 	if (db->execute(db, NULL,
-			"UPDATE pools SET end = ? WHERE name = ?",
+			db->get_driver(db) == DB_PGSQL ?
+				"UPDATE pools SET \"end\" = ? WHERE name = ?" :
+				"UPDATE pools SET end = ? WHERE name = ?",
 			DB_BLOB, new_addr, DB_TEXT, name) <= 0)
 	{
 		fprintf(stderr, "pool '%s' not found.\n", name);

--- a/src/pool/postgresql.sql
+++ b/src/pool/postgresql.sql
@@ -1,0 +1,280 @@
+/* PostgreSQL reference schema for the sql, attr_sql and pool backends.
+ * Mirrors mysql.sql: unsigned MySQL types map to the next wider signed
+ * PostgreSQL type, varbinary/BLOB map to bytea, inline INDEX clauses become
+ * named CREATE INDEX statements. */
+
+DROP TABLE IF EXISTS identities;
+CREATE TABLE identities (
+  id serial PRIMARY KEY,
+  type smallint NOT NULL,
+  data bytea NOT NULL,
+  UNIQUE (type, data)
+);
+
+
+DROP TABLE IF EXISTS child_configs;
+CREATE TABLE child_configs (
+  id serial PRIMARY KEY,
+  name varchar(32) NOT NULL,
+  lifetime integer NOT NULL default '1500',
+  rekeytime integer NOT NULL default '1200',
+  jitter integer NOT NULL default '60',
+  updown varchar(128) default NULL,
+  hostaccess smallint NOT NULL default '0',
+  mode smallint NOT NULL default '2',
+  start_action smallint NOT NULL default '0',
+  dpd_action smallint NOT NULL default '0',
+  close_action smallint NOT NULL default '0',
+  ipcomp smallint NOT NULL default '0',
+  reqid integer NOT NULL default '0'
+);
+CREATE INDEX child_configs_name ON child_configs (name);
+
+
+DROP TABLE IF EXISTS child_config_traffic_selector;
+CREATE TABLE child_config_traffic_selector (
+  child_cfg integer NOT NULL,
+  traffic_selector integer NOT NULL,
+  kind smallint NOT NULL
+);
+CREATE INDEX child_config_traffic_selector_all ON child_config_traffic_selector (child_cfg, traffic_selector);
+
+
+DROP TABLE IF EXISTS proposals;
+CREATE TABLE proposals (
+  id serial PRIMARY KEY,
+  proposal varchar(128) NOT NULL
+);
+
+
+DROP TABLE IF EXISTS child_config_proposal;
+CREATE TABLE child_config_proposal (
+  child_cfg integer NOT NULL,
+  prio integer NOT NULL,
+  prop integer NOT NULL
+);
+
+
+DROP TABLE IF EXISTS ike_configs;
+CREATE TABLE ike_configs (
+  id serial PRIMARY KEY,
+  certreq smallint NOT NULL default '1',
+  force_encap smallint NOT NULL default '0',
+  local varchar(128) NOT NULL,
+  remote varchar(128) NOT NULL
+);
+
+
+DROP TABLE IF EXISTS ike_config_proposal;
+CREATE TABLE ike_config_proposal (
+  ike_cfg integer NOT NULL,
+  prio integer NOT NULL,
+  prop integer NOT NULL
+);
+
+
+DROP TABLE IF EXISTS peer_configs;
+CREATE TABLE peer_configs (
+  id serial PRIMARY KEY,
+  name varchar(32) NOT NULL,
+  ike_version smallint NOT NULL default '2',
+  ike_cfg integer NOT NULL,
+  local_id varchar(64) NOT NULL,
+  remote_id varchar(64) NOT NULL,
+  cert_policy smallint NOT NULL default '1',
+  uniqueid smallint NOT NULL default '0',
+  auth_method smallint NOT NULL default '1',
+  eap_type smallint NOT NULL default '0',
+  eap_vendor integer NOT NULL default '0',
+  keyingtries smallint NOT NULL default '3',
+  rekeytime integer NOT NULL default '7200',
+  reauthtime integer NOT NULL default '0',
+  jitter integer NOT NULL default '180',
+  overtime integer NOT NULL default '300',
+  mobike smallint NOT NULL default '1',
+  dpd_delay integer NOT NULL default '120',
+  virtual varchar(40) default NULL,
+  pool varchar(32) default NULL,
+  mediation smallint NOT NULL default '0',
+  mediated_by integer NOT NULL default '0',
+  peer_id integer NOT NULL default '0'
+);
+CREATE INDEX peer_configs_name ON peer_configs (name);
+
+
+DROP TABLE IF EXISTS peer_config_child_config;
+CREATE TABLE peer_config_child_config (
+  peer_cfg integer NOT NULL,
+  child_cfg integer NOT NULL,
+  PRIMARY KEY (peer_cfg, child_cfg)
+);
+
+
+DROP TABLE IF EXISTS traffic_selectors;
+CREATE TABLE traffic_selectors (
+  id serial PRIMARY KEY,
+  type smallint NOT NULL default '7',
+  protocol integer NOT NULL default '0',
+  start_addr bytea default NULL,
+  end_addr bytea default NULL,
+  start_port integer NOT NULL default '0',
+  end_port integer NOT NULL default '65535'
+);
+
+
+DROP TABLE IF EXISTS certificates;
+CREATE TABLE certificates (
+  id serial PRIMARY KEY,
+  type smallint NOT NULL,
+  keytype smallint NOT NULL,
+  data bytea NOT NULL
+);
+
+
+DROP TABLE IF EXISTS certificate_identity;
+CREATE TABLE certificate_identity (
+  certificate integer NOT NULL,
+  identity integer NOT NULL,
+  PRIMARY KEY (certificate, identity)
+);
+
+
+DROP TABLE IF EXISTS private_keys;
+CREATE TABLE private_keys (
+  id serial PRIMARY KEY,
+  type smallint NOT NULL,
+  data bytea NOT NULL
+);
+
+
+DROP TABLE IF EXISTS private_key_identity;
+CREATE TABLE private_key_identity (
+  private_key integer NOT NULL,
+  identity integer NOT NULL,
+  PRIMARY KEY (private_key, identity)
+);
+
+
+DROP TABLE IF EXISTS shared_secrets;
+CREATE TABLE shared_secrets (
+  id serial PRIMARY KEY,
+  type smallint NOT NULL,
+  data bytea NOT NULL
+);
+
+
+DROP TABLE IF EXISTS shared_secret_identity;
+CREATE TABLE shared_secret_identity (
+  shared_secret integer NOT NULL,
+  identity integer NOT NULL,
+  PRIMARY KEY (shared_secret, identity)
+);
+
+
+DROP TABLE IF EXISTS certificate_authorities;
+CREATE TABLE certificate_authorities (
+  id serial PRIMARY KEY,
+  certificate integer NOT NULL
+);
+
+
+DROP TABLE IF EXISTS certificate_distribution_points;
+CREATE TABLE certificate_distribution_points (
+  id serial PRIMARY KEY,
+  ca integer NOT NULL,
+  type smallint NOT NULL,
+  uri varchar(256) NOT NULL
+);
+
+
+DROP TABLE IF EXISTS pools;
+CREATE TABLE pools (
+  id serial PRIMARY KEY,
+  name varchar(32) NOT NULL,
+  start bytea NOT NULL,
+  "end" bytea NOT NULL,
+  timeout integer NOT NULL,
+  UNIQUE (name)
+);
+
+
+DROP TABLE IF EXISTS addresses;
+CREATE TABLE addresses (
+  id serial PRIMARY KEY,
+  pool integer NOT NULL,
+  address bytea NOT NULL,
+  identity integer NOT NULL DEFAULT 0,
+  acquired integer NOT NULL DEFAULT 0,
+  released integer NOT NULL DEFAULT 1
+);
+CREATE INDEX addresses_pool ON addresses (pool);
+CREATE INDEX addresses_identity ON addresses (identity);
+CREATE INDEX addresses_address ON addresses (address);
+
+
+DROP TABLE IF EXISTS leases;
+CREATE TABLE leases (
+  id serial PRIMARY KEY,
+  address integer NOT NULL,
+  identity integer NOT NULL,
+  acquired integer NOT NULL,
+  released integer DEFAULT NULL
+);
+
+
+DROP TABLE IF EXISTS attribute_pools;
+CREATE TABLE attribute_pools (
+  id serial PRIMARY KEY,
+  name varchar(32) NOT NULL
+);
+
+
+DROP TABLE IF EXISTS attributes;
+CREATE TABLE attributes (
+  id serial PRIMARY KEY,
+  identity integer NOT NULL default '0',
+  pool integer NOT NULL default '0',
+  type integer NOT NULL,
+  value bytea NOT NULL
+);
+CREATE INDEX attributes_identity ON attributes (identity);
+CREATE INDEX attributes_pool ON attributes (pool);
+
+
+DROP TABLE IF EXISTS ike_sas;
+CREATE TABLE ike_sas (
+  local_spi bytea NOT NULL PRIMARY KEY,
+  remote_spi bytea NOT NULL,
+  id integer NOT NULL,
+  initiator smallint NOT NULL,
+  local_id_type smallint NOT NULL,
+  local_id_data bytea DEFAULT NULL,
+  remote_id_type smallint NOT NULL,
+  remote_id_data bytea DEFAULT NULL,
+  host_family smallint NOT NULL,
+  local_host_data bytea NOT NULL,
+  remote_host_data bytea NOT NULL,
+  lastuse timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+/* PostgreSQL has no ON UPDATE CURRENT_TIMESTAMP; refresh lastuse with a
+ * trigger so the sql_logger upsert keeps it current */
+CREATE OR REPLACE FUNCTION ike_sas_touch_lastuse() RETURNS trigger AS $$
+BEGIN
+  NEW.lastuse := CURRENT_TIMESTAMP;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER ike_sas_lastuse BEFORE UPDATE ON ike_sas
+  FOR EACH ROW EXECUTE FUNCTION ike_sas_touch_lastuse();
+
+
+DROP TABLE IF EXISTS logs;
+CREATE TABLE logs (
+  id serial PRIMARY KEY,
+  local_spi bytea NOT NULL,
+  signal smallint NOT NULL,
+  level smallint NOT NULL,
+  msg varchar(256) NOT NULL,
+  time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/pool/postgresql.sql
+++ b/src/pool/postgresql.sql
@@ -1,7 +1,13 @@
 /* PostgreSQL reference schema for the sql, attr_sql and pool backends.
  * Mirrors mysql.sql: unsigned MySQL types map to the next wider signed
  * PostgreSQL type, varbinary/BLOB map to bytea, inline INDEX clauses become
- * named CREATE INDEX statements. */
+ * named CREATE INDEX statements.
+ *
+ * Auto-increment keys stay serial where the id is read back through the
+ * 32-bit database bindings in the C code (config, credential and pool
+ * tables; their cardinality never approaches 2^31). The append-only
+ * accounting tables logs and leases use bigserial: their ids are never
+ * read back, and row counts there are unbounded. */
 
 DROP TABLE IF EXISTS identities;
 CREATE TABLE identities (
@@ -219,7 +225,7 @@ CREATE INDEX addresses_address ON addresses (address);
 
 DROP TABLE IF EXISTS leases;
 CREATE TABLE leases (
-  id serial PRIMARY KEY,
+  id bigserial PRIMARY KEY,
   address integer NOT NULL,
   identity integer NOT NULL,
   acquired bigint NOT NULL,
@@ -276,7 +282,7 @@ CREATE TRIGGER ike_sas_lastuse BEFORE UPDATE ON ike_sas
 
 DROP TABLE IF EXISTS logs;
 CREATE TABLE logs (
-  id serial PRIMARY KEY,
+  id bigserial PRIMARY KEY,
   local_spi bytea NOT NULL,
   signal smallint NOT NULL,
   level smallint NOT NULL,

--- a/src/pool/postgresql.sql
+++ b/src/pool/postgresql.sql
@@ -79,8 +79,10 @@ CREATE TABLE peer_configs (
   name varchar(32) NOT NULL,
   ike_version smallint NOT NULL default '2',
   ike_cfg integer NOT NULL,
-  local_id varchar(64) NOT NULL,
-  remote_id varchar(64) NOT NULL,
+  /* references identities.id; MySQL declares these varchar and relies on
+   * implicit coercion in the joins, PostgreSQL needs matching integer types */
+  local_id integer NOT NULL,
+  remote_id integer NOT NULL,
   cert_policy smallint NOT NULL default '1',
   uniqueid smallint NOT NULL default '0',
   auth_method smallint NOT NULL default '1',
@@ -192,8 +194,11 @@ CREATE TABLE pools (
   id serial PRIMARY KEY,
   name varchar(32) NOT NULL,
   start bytea NOT NULL,
+  /* END is a reserved word in PostgreSQL; pool.c quotes it for this backend */
   "end" bytea NOT NULL,
-  timeout integer NOT NULL,
+  /* Unix-time and lease-duration columns are bigint: MySQL uses unsigned int
+   * here and signed 32-bit integer overflows past 2038-01-19 */
+  timeout bigint NOT NULL,
   UNIQUE (name)
 );
 
@@ -204,8 +209,8 @@ CREATE TABLE addresses (
   pool integer NOT NULL,
   address bytea NOT NULL,
   identity integer NOT NULL DEFAULT 0,
-  acquired integer NOT NULL DEFAULT 0,
-  released integer NOT NULL DEFAULT 1
+  acquired bigint NOT NULL DEFAULT 0,
+  released bigint NOT NULL DEFAULT 1
 );
 CREATE INDEX addresses_pool ON addresses (pool);
 CREATE INDEX addresses_identity ON addresses (identity);
@@ -217,8 +222,8 @@ CREATE TABLE leases (
   id serial PRIMARY KEY,
   address integer NOT NULL,
   identity integer NOT NULL,
-  acquired integer NOT NULL,
-  released integer DEFAULT NULL
+  acquired bigint NOT NULL,
+  released bigint DEFAULT NULL
 );
 
 


### PR DESCRIPTION
## Summary

With the pgsql backend, sql_logger emitted MySQL-only syntax and PostgreSQL rejected every accounting statement, flooding the journal per packet (reported in #32):

- `REPLACE INTO ike_sas ...`: MySQL upsert, no PostgreSQL equivalent
- `INSERT INTO logs (local_spi, \`signal\`, ...)`: backtick identifier quoting

There was also no PostgreSQL reference schema at all (only mysql.sql and sqlite.sql), which is where the 'relation "peer_configs" does not exist' part of #32 comes from, and the `ipsec pool` CLI used the reserved word `end` unquoted, which PostgreSQL cannot parse.

The statements are valid for the MySQL/SQLite backends upstream targets; the PostgreSQL driver is an SW fork feature, so the dialect gap is ours.

## Changes

- sql_logger.c: both statements are selected once in sql_logger_create() based on db->get_driver(). DB_PGSQL gets `INSERT ... ON CONFLICT (local_spi) DO UPDATE SET ...` (local_spi is the ike_sas primary key per src/pool schemas) and `"signal"` double-quoted; other drivers keep the previous statements byte for byte
- src/pool/postgresql.sql: full PostgreSQL reference schema (25 tables) translated from mysql.sql, installed with the other database templates. ike_sas.lastuse is refreshed by an UPDATE trigger (mirroring MySQL's ON UPDATE CURRENT_TIMESTAMP); peer_configs.local_id/remote_id are integer to match the identities.id joins in sql_config.c; Unix-time columns (addresses/leases acquired+released, pools.timeout) are bigint and the unbounded accounting keys (logs.id, leases.id) are bigserial to survive past 2038 and past 2^31 rows
- src/pool/pool.c: the five statements referencing pools.end select a PostgreSQL variant with `"end"` double-quoted (END is reserved there); the lease-status filters bind time(NULL) as DB_UINT like every other timestamp operand
- Packaging: strongswan-pgsql now depends on strongswan-sw (= version) and the PostgreSQL schema template ships inside strongswan-pgsql; strongswan-dhcp-inform depends on versioned strongswan-sw + strongswan-pgsql. The plugins are ABI-coupled to the fork's libstrongswan build and the dialect-aware sql plugin lives in the base package, so the stock-strongswan alternative was never viable
- CodeQL: analysis scope and build extended so src/libcharon/plugins/sql and src/pool actually compile into the database (--enable-attr-sql gates the pool binary); CODEOWNERS and reviewer instructions extended accordingly

## Testing

- sql plugin and pool binary compile cleanly against the 6.0.7 tree (ubuntu:24.04, -Werror)
- postgresql.sql applies cleanly on postgres:16 (25 tables, peer_configs queryable)
- Executed on a real postgres:16 server against that schema: both sql_logger statements in the driver's $N placeholder form (upsert updates in place on repeated local_spi, lastuse trigger fires, "signal" insert succeeds), the exact peer-config join from sql_config.c, all five PostgreSQL pool.c statement variants, and post-2038 timestamp inserts
- MySQL/SQLite statement text unchanged

Closes #32