### PR TITLE
fix(dhcp-inform): export plugin version symbol required by the loader

### DIFF
--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_plugin.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_plugin.c
@@ -93,9 +93,11 @@ METHOD(plugin_t, destroy, void,
 }
 
 /*
- * Create plugin instance
+ * Create plugin instance. PLUGIN_DEFINE also emits the
+ * dhcp_inform_plugin_version symbol the plugin loader verifies before
+ * accepting a dlopen'ed plugin.
  */
-plugin_t *dhcp_inform_plugin_create()
+PLUGIN_DEFINE(dhcp_inform)
 {
 	private_dhcp_inform_plugin_t *this;
 


### PR DESCRIPTION
## Summary

charon refused to load libstrongswan-dhcp-inform.so:

```
plugin 'dhcp-inform': failed to load - version field dhcp_inform_plugin_version missing
```

Since upstream 6.0.3 the plugin loader dlopen path verifies a `<name>_plugin_version` symbol against the daemon version (HAVE_DLADDR is set in our builds, so the check is active). dhcp_inform_plugin.c declared `dhcp_inform_plugin_create()` by hand instead of using the PLUGIN_DEFINE() macro that emits both the constructor and the version symbol, so the built .so exported only the constructor. sql and pgsql use the macro and load fine. Dynamic loading of this plugin has been broken on every build since the 6.0.3 base.

## Changes

- dhcp_inform_plugin.c: replace the hand-written constructor declaration with `PLUGIN_DEFINE(dhcp_inform)` (plugin names translate '-' to '_' for the symbol lookup, so the emitted `dhcp_inform_plugin_version` matches what the loader expects)

## Testing

- Plugin rebuilt against the 6.0.7 tree (ubuntu:24.04, -Werror); nm now shows both `dhcp_inform_plugin_create` and `dhcp_inform_plugin_version`
- charon started on a clean noble install of the tree logs `plugin 'dhcp-inform': loaded successfully` (previously the loader rejected the file before any plugin code ran); subsequent provider messages are the plugin's own config gating and appear only now that it actually loads

Closes #35