### PR TITLE
fix(ci): declare /etc files as conffiles in DEB packages

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -214,6 +214,18 @@ jobs:
           LIBSSL="${{ matrix.libssl }}"
           LIBLDAP="${{ matrix.libldap }}"
 
+          # Declare every file under /etc as a conffile so dpkg preserves
+          # local changes on upgrade instead of silently overwriting them
+          # (dpkg keeps the local version and installs the new default as
+          # .dpkg-dist / prompts on conflict).
+          write_conffiles() {
+            local pkgdir="$1"
+            if [ -d "${pkgdir}/etc" ]; then
+              (cd "${pkgdir}" && find etc -type f | sed 's|^|/|' | sort) \
+                > "${pkgdir}/DEBIAN/conffiles"
+            fi
+          }
+
           # Main package
           PKGDIR="strongswan-sw_${VERSION}_${DIST}_${ARCH}"
           mkdir -p "${PKGDIR}/DEBIAN"
@@ -299,6 +311,7 @@ jobs:
             " that emits PostgreSQL statements ships there." \
             > "${PGSQL_PKGDIR}/DEBIAN/control"
 
+          write_conffiles "${PGSQL_PKGDIR}"
           fakeroot dpkg-deb --build "${PGSQL_PKGDIR}"
 
           # DHCP-Inform plugin package
@@ -347,10 +360,12 @@ jobs:
             > "${DHCP_INFORM_PKGDIR}/DEBIAN/control"
 
           if [ -n "$DHCP_INFORM_SO" ]; then
+            write_conffiles "${DHCP_INFORM_PKGDIR}"
             fakeroot dpkg-deb --build "${DHCP_INFORM_PKGDIR}"
           fi
 
           # Build the main package now that all plugin files are split out
+          write_conffiles "${PKGDIR}"
           fakeroot dpkg-deb --build "${PKGDIR}"
 
           ls -la *.deb


### PR DESCRIPTION
## Summary

Package upgrades silently reset /etc/strongswan.d configuration (reported in #37): the DEB workflow assembles packages with a hand-written DEBIAN/control only, so every file under /etc ships as an ordinary package file. With no conffiles declaration and no maintainer scripts, dpkg replaces those files unconditionally on upgrade: database DSNs, plugin settings and the VICI socket group were wiped, and the daemon restarted looking healthy while clients could no longer authenticate.

The RPM side already handles this correctly (`%config(noreplace)` on strongswan.conf, strongswan.d and swanctl.conf), so this is DEB-only.

## Changes

- build-packages.yml: generate `DEBIAN/conffiles` from the packaged `etc/` tree for strongswan-sw, strongswan-pgsql and strongswan-dhcp-inform before each dpkg-deb build. dpkg then preserves local changes on upgrade and installs new defaults as .dpkg-dist / prompts on conflict, matching stock distro strongswan packaging

## Testing

Reproduced the exact issue scenario in a clean ubuntu:24.04 container with packages assembled from a real 6.0.7 install tree:

- v1 with conffiles installs cleanly, `dpkg-query -W -f='${Conffiles}'` lists 50 entries
- after local edits (database DSN in sql.conf, `group = vpn`) an upgrade to v2 preserves both, where the previous packaging wiped them
- upgrades from the currently published packages (plain files) to a conffiles build do not silently overwrite either: dpkg detects the existing file as locally modified and keeps it under --force-confold / prompts otherwise

Closes #37