### PR TITLE
fix(dhcp-inform): receive DHCPINFORM over UDP and restore identity route lookup

### DIFF
--- a/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
+++ b/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
@@ -16,7 +16,12 @@ dhcp-inform {
     # Server IP address (required - usually the VPN gateway IP)
     server = 172.16.69.1
 
-    # VPN interface to listen on (optional, listens on all if not set)
+    # VPN interface to bind the DHCP socket to (optional). The binding
+    # covers both directions: DHCPINFORM is accepted only from this
+    # interface and DHCPACK egresses through it. Leave unset on
+    # asymmetrically routed or multi-homed gateways so replies follow the
+    # routing table; without it, sender verification and the IPsec policy
+    # still protect the responder.
     # interface = eth0
 
     # DNS server to advertise (optional)

--- a/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
+++ b/src/libcharon/plugins/dhcp_inform/dhcp-inform.conf
@@ -34,11 +34,20 @@ dhcp-inform {
     # =========================================================================
     # MODE 2: Database Routes (second priority)
     # =========================================================================
-    # Routes are queried from database by matching client IP to pool CIDR.
     # Used when TS routes disabled. Takes priority over static routes.
     # Works with PostgreSQL, MySQL, SQLite via strongSwan database abstraction.
     #
-    # Requires VIEW v_pool_routes (pool_cidr TEXT, route TEXT):
+    # Two VIEWs are consulted, each optional, results are merged:
+    #
+    # v_user_routes (identity TEXT, resource_type TEXT, resource_value TEXT):
+    #   per-identity routes for the client's IKE identity (domain part after
+    #   '@' is stripped: user@example.org looks up as "user")
+    #   - resource_type "ip":   resource_value is a host address (/32 route)
+    #   - resource_type "cidr": resource_value is a subnet in CIDR notation
+    #   - resource_type "fqdn": resource_value is resolved to a /32 route
+    #
+    # v_pool_routes (pool_cidr TEXT, route TEXT):
+    #   per-pool routes for every client whose virtual IP is inside pool_cidr
     #   - pool_cidr: CIDR notation (e.g., "10.0.0.0/8")
     #   - route: route to push to clients in this pool
     #

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -43,7 +43,7 @@ typedef struct {
 	uint32_t addr;
 	/** monotonic time after which a refresh becomes due */
 	time_t expires;
-	/** a background resolution job is in flight */
+	/** the name is queued for background resolution */
 	bool resolving;
 } fqdn_entry_t;
 
@@ -68,9 +68,19 @@ struct private_dhcp_inform_db_provider_t {
 	hashtable_t *fqdn_cache;
 
 	/**
-	 * Lock for the FQDN cache
+	 * Lock for the FQDN cache and the pending queue
 	 */
 	mutex_t *mutex;
+
+	/**
+	 * FQDNs queued for background resolution, char*, owned
+	 */
+	linked_list_t *pending;
+
+	/**
+	 * The single resolver job is queued or running
+	 */
+	bool resolver_active;
 };
 
 /* Maximum CIDR string length for IPv4: "255.255.255.255/32" = 18 chars.
@@ -199,73 +209,86 @@ static bool ip_in_subnet(host_t *ip, host_t *network, uint8_t prefix)
 }
 
 /**
- * Data for a background FQDN resolution job. The provider outlives every
- * queued job: the daemon cancels all processor jobs before plugins unload.
+ * Drain the pending queue on a single worker thread: names resolve one at
+ * a time, so a slow resolver occupies at most one of charon's processor
+ * threads no matter how many names are queued. The provider outlives the
+ * job: the daemon cancels all processor jobs before plugins unload.
  */
-typedef struct {
-	/** provider owning the cache */
-	private_dhcp_inform_db_provider_t *provider;
-	/** name to resolve, owned */
-	char *fqdn;
-} fqdn_job_t;
-
-/**
- * Destroy background resolution job data
- */
-static void fqdn_job_destroy(fqdn_job_t *job)
+static job_requeue_t resolve_pending_job(private_dhcp_inform_db_provider_t *this)
 {
-	free(job->fqdn);
-	free(job);
-}
-
-/**
- * Resolve an FQDN on a worker thread and store the outcome in the cache;
- * failures are cached too, with a shorter TTL, so an unreachable resolver
- * is retried at most once per window
- */
-static job_requeue_t resolve_fqdn_job(fqdn_job_t *job)
-{
-	private_dhcp_inform_db_provider_t *this = job->provider;
 	struct addrinfo hints, *res;
 	fqdn_entry_t *entry;
-	uint32_t ip_addr = 0;
+	uint32_t ip_addr;
+	char *fqdn;
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_INET;
 	hints.ai_socktype = SOCK_STREAM;
 
-	if (getaddrinfo(job->fqdn, NULL, &hints, &res) == 0)
+	while (TRUE)
 	{
-		if (res->ai_family == AF_INET)
+		this->mutex->lock(this->mutex);
+		if (this->pending->get_first(this->pending, (void**)&fqdn) != SUCCESS)
 		{
-			struct sockaddr_in *sin = (struct sockaddr_in*)res->ai_addr;
-			ip_addr = sin->sin_addr.s_addr;
+			this->resolver_active = FALSE;
+			this->mutex->unlock(this->mutex);
+			return JOB_REQUEUE_NONE;
 		}
-		freeaddrinfo(res);
-		DBG2(DBG_CFG, "dhcp-inform-db: resolved FQDN %s", job->fqdn);
-	}
-	else
-	{
-		DBG1(DBG_CFG, "dhcp-inform-db: failed to resolve FQDN: %s", job->fqdn);
-	}
+		this->mutex->unlock(this->mutex);
 
-	this->mutex->lock(this->mutex);
-	entry = this->fqdn_cache->get(this->fqdn_cache, job->fqdn);
-	if (entry)
-	{
-		if (ip_addr)
+		/* the head entry stays queued while it resolves: producers only
+		 * append, and on job cancellation the list still owns the string */
+		ip_addr = 0;
+		if (getaddrinfo(fqdn, NULL, &hints, &res) == 0)
 		{
-			entry->addr = ip_addr;
+			if (res->ai_family == AF_INET)
+			{
+				struct sockaddr_in *sin = (struct sockaddr_in*)res->ai_addr;
+				ip_addr = sin->sin_addr.s_addr;
+			}
+			freeaddrinfo(res);
+			DBG2(DBG_CFG, "dhcp-inform-db: resolved FQDN %s", fqdn);
 		}
-		/* a failed refresh keeps the last known address serving and only
-		 * shortens the interval until the next attempt */
-		entry->expires = time_monotonic(NULL) +
-						 (ip_addr ? FQDN_CACHE_TTL : FQDN_NEGATIVE_TTL);
-		entry->resolving = FALSE;
-	}
-	this->mutex->unlock(this->mutex);
+		else
+		{
+			DBG1(DBG_CFG, "dhcp-inform-db: failed to resolve FQDN: %s", fqdn);
+		}
 
-	return JOB_REQUEUE_NONE;
+		this->mutex->lock(this->mutex);
+		entry = this->fqdn_cache->get(this->fqdn_cache, fqdn);
+		if (entry)
+		{
+			if (ip_addr)
+			{
+				entry->addr = ip_addr;
+			}
+			/* a failed refresh keeps the last known address serving and only
+			 * shortens the interval until the next attempt */
+			entry->expires = time_monotonic(NULL) +
+							 (ip_addr ? FQDN_CACHE_TTL : FQDN_NEGATIVE_TTL);
+			entry->resolving = FALSE;
+		}
+		this->pending->remove_first(this->pending, (void**)&fqdn);
+		this->mutex->unlock(this->mutex);
+		free(fqdn);
+	}
+}
+
+/**
+ * Queue a name for background resolution; the caller holds the mutex and
+ * has already marked the cache entry as resolving
+ */
+static void queue_resolution(private_dhcp_inform_db_provider_t *this,
+							 const char *fqdn)
+{
+	this->pending->insert_last(this->pending, strdup(fqdn));
+	if (!this->resolver_active)
+	{
+		this->resolver_active = TRUE;
+		lib->processor->queue_job(lib->processor,
+			(job_t*)callback_job_create((callback_job_cb_t)resolve_pending_job,
+										this, NULL, callback_job_cancel_thread));
+	}
 }
 
 /**
@@ -278,7 +301,6 @@ METHOD(dhcp_inform_db_provider_t, prewarm, void,
 {
 	enumerator_t *enumerator;
 	fqdn_entry_t *entry;
-	fqdn_job_t *job;
 	char *fqdn;
 
 	if (!this->db)
@@ -309,14 +331,7 @@ METHOD(dhcp_inform_db_provider_t, prewarm, void,
 				.resolving = TRUE,
 			);
 			this->fqdn_cache->put(this->fqdn_cache, strdup(fqdn), entry);
-			INIT(job,
-				.provider = this,
-				.fqdn = strdup(fqdn),
-			);
-			lib->processor->queue_job(lib->processor,
-				(job_t*)callback_job_create(
-					(callback_job_cb_t)resolve_fqdn_job, job,
-					(void*)fqdn_job_destroy, callback_job_cancel_thread));
+			queue_resolution(this, fqdn);
 		}
 		this->mutex->unlock(this->mutex);
 	}
@@ -333,7 +348,6 @@ static uint32_t resolve_fqdn(private_dhcp_inform_db_provider_t *this,
 							 const char *fqdn)
 {
 	fqdn_entry_t *entry;
-	fqdn_job_t *job = NULL;
 	uint32_t ip_addr = 0;
 	time_t now;
 
@@ -350,20 +364,9 @@ static uint32_t resolve_fqdn(private_dhcp_inform_db_provider_t *this,
 	if (entry->expires <= now && !entry->resolving)
 	{
 		entry->resolving = TRUE;
-		INIT(job,
-			.provider = this,
-			.fqdn = strdup(fqdn),
-		);
+		queue_resolution(this, fqdn);
 	}
 	this->mutex->unlock(this->mutex);
-
-	if (job)
-	{
-		lib->processor->queue_job(lib->processor,
-			(job_t*)callback_job_create((callback_job_cb_t)resolve_fqdn_job,
-										job, (void*)fqdn_job_destroy,
-										callback_job_cancel_thread));
-	}
 
 	return ip_addr;
 }
@@ -645,6 +648,7 @@ METHOD(dhcp_inform_provider_t, destroy, void,
 	private_dhcp_inform_db_provider_t *this)
 {
 	this->fqdn_cache->destroy_function(this->fqdn_cache, fqdn_entry_destroy);
+	this->pending->destroy_function(this->pending, free);
 	this->mutex->destroy(this->mutex);
 	DESTROY_IF(this->db);
 	free(this);
@@ -670,6 +674,7 @@ dhcp_inform_db_provider_t *dhcp_inform_db_provider_create()
 		},
 		.fqdn_cache = hashtable_create(hashtable_hash_str,
 									   hashtable_equals_str, 4),
+		.pending = linked_list_create(),
 		.mutex = mutex_create(MUTEX_TYPE_DEFAULT),
 	);
 

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -40,6 +40,13 @@
  */
 #define FQDN_MAX_STALE 3600
 
+/**
+ * How long a failed v_user_routes query disables the identity path before
+ * the next request probes again, in seconds; the view may be created while
+ * the daemon runs
+ */
+#define USER_ROUTES_RECHECK 60
+
 typedef struct private_dhcp_inform_db_provider_t private_dhcp_inform_db_provider_t;
 
 /**
@@ -90,6 +97,16 @@ struct private_dhcp_inform_db_provider_t {
 	 * The single resolver job is queued or running
 	 */
 	bool resolver_active;
+
+	/**
+	 * The optional v_user_routes view was usable when last queried
+	 */
+	bool user_routes;
+
+	/**
+	 * When unusable: monotonic time after which a request probes again
+	 */
+	time_t user_routes_recheck;
 };
 
 /* Maximum CIDR string length for IPv4: "255.255.255.255/32" = 18 chars.
@@ -323,6 +340,24 @@ static void queue_resolution(private_dhcp_inform_db_provider_t *this,
  * v_user_routes, so the cache is warm before the first DHCPINFORM arrives
  * and cold names cost a route only when added to the database at runtime
  */
+METHOD(dhcp_inform_db_provider_t, uses_identity, bool,
+	private_dhcp_inform_db_provider_t *this)
+{
+	bool usable;
+
+	if (!this->db)
+	{
+		return FALSE;
+	}
+	this->mutex->lock(this->mutex);
+	/* past the recheck time one request runs the identity path again as a
+	 * probe: its query outcome refreshes this state either way */
+	usable = this->user_routes ||
+			 time_monotonic(NULL) >= this->user_routes_recheck;
+	this->mutex->unlock(this->mutex);
+	return usable;
+}
+
 METHOD(dhcp_inform_db_provider_t, prewarm, void,
 	private_dhcp_inform_db_provider_t *this)
 {
@@ -341,6 +376,15 @@ METHOD(dhcp_inform_db_provider_t, prewarm, void,
 		DB_TEXT);
 	if (!enumerator)
 	{
+		/* pool-only schema: remember that the optional view is absent so
+		 * requests skip the identity lookup and its doomed query until the
+		 * next periodic probe; the view may be created later */
+		this->mutex->lock(this->mutex);
+		this->user_routes = FALSE;
+		this->user_routes_recheck = time_monotonic(NULL) + USER_ROUTES_RECHECK;
+		this->mutex->unlock(this->mutex);
+		DBG1(DBG_CFG, "dhcp-inform-db: v_user_routes not queryable, "
+			 "identity routes disabled for %ds", USER_ROUTES_RECHECK);
 		return;
 	}
 
@@ -505,9 +549,17 @@ static int add_identity_routes(private_dhcp_inform_db_provider_t *this,
 
 	if (!enumerator)
 	{
-		DBG2(DBG_CFG, "dhcp-inform-db: v_user_routes not available");
+		DBG1(DBG_CFG, "dhcp-inform-db: v_user_routes not queryable, "
+			 "identity routes disabled for %ds", USER_ROUTES_RECHECK);
+		this->mutex->lock(this->mutex);
+		this->user_routes = FALSE;
+		this->user_routes_recheck = time_monotonic(NULL) + USER_ROUTES_RECHECK;
+		this->mutex->unlock(this->mutex);
 		return 0;
 	}
+	this->mutex->lock(this->mutex);
+	this->user_routes = TRUE;
+	this->mutex->unlock(this->mutex);
 
 	while (enumerator->enumerate(enumerator, &resource_type, &resource_value))
 	{
@@ -698,11 +750,14 @@ dhcp_inform_db_provider_t *dhcp_inform_db_provider_create()
 				.destroy = _destroy,
 			},
 			.prewarm = _prewarm,
+			.uses_identity = _uses_identity,
 		},
 		.fqdn_cache = hashtable_create(hashtable_hash_str,
 									   hashtable_equals_str, 4),
 		.pending = linked_list_create(),
 		.mutex = mutex_create(MUTEX_TYPE_DEFAULT),
+		/* assumed present until the prewarm probe learns otherwise */
+		.user_routes = TRUE,
 	);
 
 	/* Get database URI from configuration */

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -15,6 +15,11 @@
 #include <selectors/traffic_selector.h>
 #include <networking/host.h>
 
+#include <string.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
 typedef struct private_dhcp_inform_db_provider_t private_dhcp_inform_db_provider_t;
 
 /**
@@ -158,54 +163,173 @@ static bool ip_in_subnet(host_t *ip, host_t *network, uint8_t prefix)
 	return TRUE;
 }
 
-METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
-	private_dhcp_inform_db_provider_t *this, const char *client_ip)
+/**
+ * Resolve an FQDN to an IPv4 address (network byte order), 0 on failure
+ */
+static uint32_t resolve_fqdn(const char *fqdn)
 {
-	linked_list_t *routes;
+	struct addrinfo hints, *res;
+	uint32_t ip_addr = 0;
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+
+	if (getaddrinfo(fqdn, NULL, &hints, &res) == 0)
+	{
+		if (res->ai_family == AF_INET)
+		{
+			struct sockaddr_in *sin = (struct sockaddr_in*)res->ai_addr;
+			ip_addr = sin->sin_addr.s_addr;
+		}
+		freeaddrinfo(res);
+	}
+	else
+	{
+		DBG1(DBG_CFG, "dhcp-inform-db: failed to resolve FQDN: %s", fqdn);
+	}
+
+	return ip_addr;
+}
+
+/**
+ * Build a traffic selector from a v_user_routes resource:
+ * "ip" and "fqdn" become host routes, "cidr" a subnet route
+ */
+static traffic_selector_t *resource_to_ts(const char *type, const char *value)
+{
+	traffic_selector_t *ts = NULL;
+	host_t *host;
+
+	if (streq(type, "ip"))
+	{
+		host = host_create_from_string((char*)value, 0);
+		if (host)
+		{
+			ts = traffic_selector_create_from_subnet(host, 32, 0, 0, 65535);
+		}
+	}
+	else if (streq(type, "cidr"))
+	{
+		ts = parse_cidr(value);
+	}
+	else if (streq(type, "fqdn"))
+	{
+		uint32_t ip_addr = resolve_fqdn(value);
+
+		if (ip_addr)
+		{
+			host = host_create_from_chunk(AF_INET,
+					chunk_create((char*)&ip_addr, 4), 0);
+			if (host)
+			{
+				ts = traffic_selector_create_from_subnet(host, 32, 0, 0, 65535);
+			}
+		}
+	}
+	else
+	{
+		DBG2(DBG_CFG, "dhcp-inform-db: unknown resource type=%s value=%s",
+			 type, value);
+	}
+
+	return ts;
+}
+
+/**
+ * Add per-identity routes from the v_user_routes VIEW:
+ * (identity, resource_type, resource_value). The identity is matched
+ * without a domain part, so user@example.org looks up as "user".
+ * A missing view is not an error, deployments may use v_pool_routes only.
+ */
+static int add_identity_routes(private_dhcp_inform_db_provider_t *this,
+							   identification_t *identity,
+							   linked_list_t *routes)
+{
+	enumerator_t *enumerator;
+	chunk_t id_data;
+	char *identity_str, *at;
+	char *resource_type, *resource_value;
+	int added = 0;
+
+	id_data = identity->get_encoding(identity);
+	identity_str = strndup(id_data.ptr, id_data.len);
+	if (!identity_str)
+	{
+		return 0;
+	}
+	at = strchr(identity_str, '@');
+	if (at)
+	{
+		*at = '\0';
+	}
+
+	DBG2(DBG_CFG, "dhcp-inform-db: looking up routes for identity %s",
+		 identity_str);
+
+	enumerator = this->db->query(this->db,
+		"SELECT resource_type, resource_value FROM v_user_routes "
+		"WHERE identity = ?",
+		DB_TEXT, identity_str,
+		DB_TEXT, DB_TEXT);
+
+	if (!enumerator)
+	{
+		DBG2(DBG_CFG, "dhcp-inform-db: v_user_routes not available");
+		free(identity_str);
+		return 0;
+	}
+
+	while (enumerator->enumerate(enumerator, &resource_type, &resource_value))
+	{
+		traffic_selector_t *ts;
+
+		if (!resource_type || !resource_value)
+		{
+			continue;
+		}
+
+		ts = resource_to_ts(resource_type, resource_value);
+		if (ts)
+		{
+			routes->insert_last(routes, ts);
+			added++;
+			DBG2(DBG_CFG, "dhcp-inform-db: added route %R for %s",
+				 ts, identity_str);
+		}
+	}
+	enumerator->destroy(enumerator);
+
+	if (added)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-db: found %d routes for identity %s",
+			 added, identity_str);
+	}
+	free(identity_str);
+
+	return added;
+}
+
+/**
+ * Add per-pool routes from the v_pool_routes VIEW: (pool_cidr, route).
+ * All pairs are fetched and filtered in C for database portability
+ * (works with PostgreSQL, MySQL, SQLite via the database abstraction).
+ */
+static int add_pool_routes(private_dhcp_inform_db_provider_t *this,
+						   host_t *client, linked_list_t *routes)
+{
 	enumerator_t *enumerator;
 	char *pool_cidr, *route_value;
-	host_t *client;
-	int routes_added = 0;
+	int added = 0;
 
-	routes = linked_list_create();
-	if (!routes)
-	{
-		return NULL;
-	}
-
-	if (!this->db)
-	{
-		return routes;
-	}
-
-	if (!client_ip || !*client_ip)
-	{
-		DBG1(DBG_CFG, "dhcp-inform-db: empty client IP");
-		return routes;
-	}
-
-	client = host_create_from_string((char*)client_ip, 0);
-	if (!client)
-	{
-		DBG1(DBG_CFG, "dhcp-inform-db: invalid client IP: %s", client_ip);
-		return routes;
-	}
-
-	DBG2(DBG_CFG, "dhcp-inform-db: looking up routes for IP %s", client_ip);
-
-	/* Query all pool/route pairs, filter in C for database portability.
-	 * Uses v_pool_routes VIEW: (pool_cidr, route).
-	 * Works with PostgreSQL, MySQL, SQLite via strongSwan database abstraction.
-	 */
 	enumerator = this->db->query(this->db,
 		"SELECT pool_cidr, route FROM v_pool_routes",
 		DB_TEXT, DB_TEXT);
 
 	if (!enumerator)
 	{
-		DBG1(DBG_CFG, "dhcp-inform-db: query failed");
-		client->destroy(client);
-		return routes;
+		DBG2(DBG_CFG, "dhcp-inform-db: v_pool_routes not available");
+		return 0;
 	}
 
 	while (enumerator->enumerate(enumerator, &pool_cidr, &route_value))
@@ -238,15 +362,62 @@ METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
 		if (ts)
 		{
 			routes->insert_last(routes, ts);
-			routes_added++;
+			added++;
 			DBG2(DBG_CFG, "dhcp-inform-db: added route %s from pool %s",
 				 route_value, pool_cidr);
 		}
 	}
 	enumerator->destroy(enumerator);
+
+	return added;
+}
+
+METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
+	private_dhcp_inform_db_provider_t *this, const char *client_ip,
+	identification_t *identity)
+{
+	linked_list_t *routes;
+	host_t *client;
+	int routes_added = 0;
+
+	routes = linked_list_create();
+	if (!routes)
+	{
+		return NULL;
+	}
+
+	if (!this->db)
+	{
+		return routes;
+	}
+
+	if (!client_ip || !*client_ip)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-db: empty client IP");
+		return routes;
+	}
+
+	client = host_create_from_string((char*)client_ip, 0);
+	if (!client)
+	{
+		DBG1(DBG_CFG, "dhcp-inform-db: invalid client IP: %s", client_ip);
+		return routes;
+	}
+
+	DBG2(DBG_CFG, "dhcp-inform-db: looking up routes for IP %s", client_ip);
+
+	/* Per-identity routes first, per-pool routes on top; the responder
+	 * deduplicates overlapping entries */
+	if (identity)
+	{
+		routes_added += add_identity_routes(this, identity, routes);
+	}
+	routes_added += add_pool_routes(this, client, routes);
+
 	client->destroy(client);
 
-	DBG1(DBG_CFG, "dhcp-inform-db: found %d routes for %s", routes_added, client_ip);
+	DBG1(DBG_CFG, "dhcp-inform-db: found %d routes for %s", routes_added,
+		 client_ip);
 
 	return routes;
 }

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -253,7 +253,12 @@ static job_requeue_t resolve_fqdn_job(fqdn_job_t *job)
 	entry = this->fqdn_cache->get(this->fqdn_cache, job->fqdn);
 	if (entry)
 	{
-		entry->addr = ip_addr;
+		if (ip_addr)
+		{
+			entry->addr = ip_addr;
+		}
+		/* a failed refresh keeps the last known address serving and only
+		 * shortens the interval until the next attempt */
 		entry->expires = time_monotonic(NULL) +
 						 (ip_addr ? FQDN_CACHE_TTL : FQDN_NEGATIVE_TTL);
 		entry->resolving = FALSE;

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -16,6 +16,7 @@
 #include <selectors/traffic_selector.h>
 #include <networking/host.h>
 #include <threading/mutex.h>
+#include <threading/thread.h>
 #include <processing/jobs/callback_job.h>
 
 #include <string.h>
@@ -228,6 +229,7 @@ static job_requeue_t resolve_pending_job(private_dhcp_inform_db_provider_t *this
 	fqdn_entry_t *entry;
 	uint32_t ip_addr;
 	char *fqdn;
+	bool old;
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_INET;
@@ -247,6 +249,11 @@ static job_requeue_t resolve_pending_job(private_dhcp_inform_db_provider_t *this
 		/* the head entry stays queued while it resolves: producers only
 		 * append, and on job cancellation the list still owns the string */
 		ip_addr = 0;
+		/* workers run with cancellation disabled: enable it around the
+		 * blocking lookup so the thread cancel that shutdown requests can
+		 * take effect instead of leaving processor teardown waiting on a
+		 * stuck resolution; no lock is held and the job owns no memory */
+		old = thread_cancelability(TRUE);
 		if (getaddrinfo(fqdn, NULL, &hints, &res) == 0)
 		{
 			if (res->ai_family == AF_INET)
@@ -261,6 +268,7 @@ static job_requeue_t resolve_pending_job(private_dhcp_inform_db_provider_t *this
 		{
 			DBG1(DBG_CFG, "dhcp-inform-db: failed to resolve FQDN: %s", fqdn);
 		}
+		thread_cancelability(old);
 
 		this->mutex->lock(this->mutex);
 		entry = this->fqdn_cache->get(this->fqdn_cache, fqdn);

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -340,6 +340,52 @@ static void queue_resolution(private_dhcp_inform_db_provider_t *this,
  * v_user_routes, so the cache is warm before the first DHCPINFORM arrives
  * and cold names cost a route only when added to the database at runtime
  */
+/**
+ * Record whether the last v_user_routes query was usable; failures re-arm
+ * the periodic probe
+ */
+static void update_user_routes_state(private_dhcp_inform_db_provider_t *this,
+									 bool usable)
+{
+	this->mutex->lock(this->mutex);
+	this->user_routes = usable;
+	if (!usable)
+	{
+		this->user_routes_recheck = time_monotonic(NULL) + USER_ROUTES_RECHECK;
+	}
+	this->mutex->unlock(this->mutex);
+}
+
+/**
+ * When the recheck window has expired and no identity query ran, test the
+ * view with an empty-identity lookup so the probe state still advances:
+ * without this an expired window would re-run the SA scan on every request
+ * until some peer matches
+ */
+static void probe_user_routes(private_dhcp_inform_db_provider_t *this)
+{
+	enumerator_t *enumerator;
+	bool due;
+
+	this->mutex->lock(this->mutex);
+	due = !this->user_routes &&
+		  time_monotonic(NULL) >= this->user_routes_recheck;
+	this->mutex->unlock(this->mutex);
+	if (!due)
+	{
+		return;
+	}
+	enumerator = this->db->query(this->db,
+		"SELECT resource_type, resource_value FROM v_user_routes "
+		"WHERE identity = ''",
+		DB_TEXT, DB_TEXT);
+	if (enumerator)
+	{
+		enumerator->destroy(enumerator);
+	}
+	update_user_routes_state(this, enumerator != NULL);
+}
+
 METHOD(dhcp_inform_db_provider_t, uses_identity, bool,
 	private_dhcp_inform_db_provider_t *this)
 {
@@ -379,10 +425,7 @@ METHOD(dhcp_inform_db_provider_t, prewarm, void,
 		/* pool-only schema: remember that the optional view is absent so
 		 * requests skip the identity lookup and its doomed query until the
 		 * next periodic probe; the view may be created later */
-		this->mutex->lock(this->mutex);
-		this->user_routes = FALSE;
-		this->user_routes_recheck = time_monotonic(NULL) + USER_ROUTES_RECHECK;
-		this->mutex->unlock(this->mutex);
+		update_user_routes_state(this, FALSE);
 		DBG1(DBG_CFG, "dhcp-inform-db: v_user_routes not queryable, "
 			 "identity routes disabled for %ds", USER_ROUTES_RECHECK);
 		return;
@@ -551,15 +594,10 @@ static int add_identity_routes(private_dhcp_inform_db_provider_t *this,
 	{
 		DBG1(DBG_CFG, "dhcp-inform-db: v_user_routes not queryable, "
 			 "identity routes disabled for %ds", USER_ROUTES_RECHECK);
-		this->mutex->lock(this->mutex);
-		this->user_routes = FALSE;
-		this->user_routes_recheck = time_monotonic(NULL) + USER_ROUTES_RECHECK;
-		this->mutex->unlock(this->mutex);
+		update_user_routes_state(this, FALSE);
 		return 0;
 	}
-	this->mutex->lock(this->mutex);
-	this->user_routes = TRUE;
-	this->mutex->unlock(this->mutex);
+	update_user_routes_state(this, TRUE);
 
 	while (enumerator->enumerate(enumerator, &resource_type, &resource_value))
 	{
@@ -691,6 +729,10 @@ METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
 	if (identity)
 	{
 		routes_added += add_identity_routes(this, identity, routes);
+	}
+	else
+	{
+		probe_user_routes(this);
 	}
 	routes_added += add_pool_routes(this, client, routes);
 

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -33,6 +33,12 @@
  */
 #define FQDN_NEGATIVE_TTL 60
 
+/**
+ * How long a stale address keeps serving while refreshes fail, in seconds;
+ * past this bound the name is treated as gone and its route stops
+ */
+#define FQDN_MAX_STALE 3600
+
 typedef struct private_dhcp_inform_db_provider_t private_dhcp_inform_db_provider_t;
 
 /**
@@ -43,6 +49,8 @@ typedef struct {
 	uint32_t addr;
 	/** monotonic time after which a refresh becomes due */
 	time_t expires;
+	/** monotonic time of the last successful resolution */
+	time_t last_ok;
 	/** the name is queued for background resolution */
 	bool resolving;
 } fqdn_entry_t;
@@ -258,13 +266,24 @@ static job_requeue_t resolve_pending_job(private_dhcp_inform_db_provider_t *this
 		entry = this->fqdn_cache->get(this->fqdn_cache, fqdn);
 		if (entry)
 		{
+			time_t now = time_monotonic(NULL);
+
 			if (ip_addr)
 			{
 				entry->addr = ip_addr;
+				entry->last_ok = now;
 			}
-			/* a failed refresh keeps the last known address serving and only
-			 * shortens the interval until the next attempt */
-			entry->expires = time_monotonic(NULL) +
+			else if (entry->addr && now - entry->last_ok > FQDN_MAX_STALE)
+			{
+				/* unresolvable for so long that the last address can no
+				 * longer be trusted: stop advertising the route */
+				DBG1(DBG_CFG, "dhcp-inform-db: FQDN %s stale beyond bound, "
+					 "dropping cached address", fqdn);
+				entry->addr = 0;
+			}
+			/* a failed refresh keeps the last known address serving, within
+			 * the stale bound, and only shortens the retry interval */
+			entry->expires = now +
 							 (ip_addr ? FQDN_CACHE_TTL : FQDN_NEGATIVE_TTL);
 			entry->resolving = FALSE;
 		}

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -338,10 +338,15 @@ static int add_identity_routes(private_dhcp_inform_db_provider_t *this,
 		DBG1(DBG_CFG, "dhcp-inform-db: identity too long for route lookup");
 		return 0;
 	}
-	at = strchr(identity_str, '@');
-	if (at)
+	/* strip the domain part of mail-style identities only; a DN can
+	 * legitimately contain '@' inside an emailAddress component */
+	if (identity->get_type(identity) == ID_RFC822_ADDR)
 	{
-		*at = '\0';
+		at = strchr(identity_str, '@');
+		if (at)
+		{
+			*at = '\0';
+		}
 	}
 
 	DBG2(DBG_CFG, "dhcp-inform-db: looking up routes for identity %s",

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -11,16 +11,33 @@
 
 #include <daemon.h>
 #include <collections/linked_list.h>
+#include <collections/hashtable.h>
 #include <database/database.h>
 #include <selectors/traffic_selector.h>
 #include <networking/host.h>
+#include <threading/mutex.h>
 
 #include <string.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 
+/**
+ * How long a resolved FQDN stays cached, in seconds
+ */
+#define FQDN_CACHE_TTL 300
+
 typedef struct private_dhcp_inform_db_provider_t private_dhcp_inform_db_provider_t;
+
+/**
+ * Cached FQDN resolution
+ */
+typedef struct {
+	/** resolved address, network byte order */
+	uint32_t addr;
+	/** monotonic expiry time */
+	time_t expires;
+} fqdn_entry_t;
 
 /**
  * Private data
@@ -36,6 +53,16 @@ struct private_dhcp_inform_db_provider_t {
 	 * Database connection
 	 */
 	database_t *db;
+
+	/**
+	 * FQDN resolution cache, fqdn string => fqdn_entry_t
+	 */
+	hashtable_t *fqdn_cache;
+
+	/**
+	 * Lock for the FQDN cache
+	 */
+	mutex_t *mutex;
 };
 
 /* Maximum CIDR string length for IPv4: "255.255.255.255/32" = 18 chars.
@@ -164,12 +191,32 @@ static bool ip_in_subnet(host_t *ip, host_t *network, uint8_t prefix)
 }
 
 /**
- * Resolve an FQDN to an IPv4 address (network byte order), 0 on failure
+ * Resolve an FQDN to an IPv4 address (network byte order), 0 on failure.
+ * Successful resolutions are cached, so the synchronous getaddrinfo() call
+ * hits the request path at most once per FQDN and TTL window.
  */
-static uint32_t resolve_fqdn(const char *fqdn)
+static uint32_t resolve_fqdn(private_dhcp_inform_db_provider_t *this,
+							 const char *fqdn)
 {
 	struct addrinfo hints, *res;
+	fqdn_entry_t *entry;
 	uint32_t ip_addr = 0;
+	time_t now;
+
+	now = time_monotonic(NULL);
+
+	this->mutex->lock(this->mutex);
+	entry = this->fqdn_cache->get(this->fqdn_cache, (void*)fqdn);
+	if (entry && entry->expires > now)
+	{
+		ip_addr = entry->addr;
+	}
+	this->mutex->unlock(this->mutex);
+
+	if (ip_addr)
+	{
+		return ip_addr;
+	}
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_INET;
@@ -189,14 +236,30 @@ static uint32_t resolve_fqdn(const char *fqdn)
 		DBG1(DBG_CFG, "dhcp-inform-db: failed to resolve FQDN: %s", fqdn);
 	}
 
+	if (ip_addr)
+	{
+		this->mutex->lock(this->mutex);
+		entry = this->fqdn_cache->get(this->fqdn_cache, (void*)fqdn);
+		if (!entry)
+		{
+			INIT(entry);
+			this->fqdn_cache->put(this->fqdn_cache, strdup(fqdn), entry);
+		}
+		entry->addr = ip_addr;
+		entry->expires = now + FQDN_CACHE_TTL;
+		this->mutex->unlock(this->mutex);
+	}
+
 	return ip_addr;
 }
 
 /**
  * Build a traffic selector from a v_user_routes resource:
- * "ip" and "fqdn" become host routes, "cidr" a subnet route
+ * "ip" and "fqdn" become host routes, "cidr" a subnet route.
+ * DHCP options 121/249 encode IPv4 only, so other families are skipped.
  */
-static traffic_selector_t *resource_to_ts(const char *type, const char *value)
+static traffic_selector_t *resource_to_ts(private_dhcp_inform_db_provider_t *this,
+										  const char *type, const char *value)
 {
 	traffic_selector_t *ts = NULL;
 	host_t *host;
@@ -206,16 +269,32 @@ static traffic_selector_t *resource_to_ts(const char *type, const char *value)
 		host = host_create_from_string((char*)value, 0);
 		if (host)
 		{
-			ts = traffic_selector_create_from_subnet(host, 32, 0, 0, 65535);
+			if (host->get_family(host) == AF_INET)
+			{
+				ts = traffic_selector_create_from_subnet(host, 32, 0, 0, 65535);
+			}
+			else
+			{
+				DBG1(DBG_CFG, "dhcp-inform-db: ignoring non-IPv4 ip resource %s",
+					 value);
+				host->destroy(host);
+			}
 		}
 	}
 	else if (streq(type, "cidr"))
 	{
 		ts = parse_cidr(value);
+		if (ts && ts->get_type(ts) != TS_IPV4_ADDR_RANGE)
+		{
+			DBG1(DBG_CFG, "dhcp-inform-db: ignoring non-IPv4 cidr resource %s",
+				 value);
+			ts->destroy(ts);
+			ts = NULL;
+		}
 	}
 	else if (streq(type, "fqdn"))
 	{
-		uint32_t ip_addr = resolve_fqdn(value);
+		uint32_t ip_addr = resolve_fqdn(this, value);
 
 		if (ip_addr)
 		{
@@ -247,15 +326,16 @@ static int add_identity_routes(private_dhcp_inform_db_provider_t *this,
 							   linked_list_t *routes)
 {
 	enumerator_t *enumerator;
-	chunk_t id_data;
-	char *identity_str, *at;
+	char identity_str[256], *at;
 	char *resource_type, *resource_value;
-	int added = 0;
+	int added = 0, written;
 
-	id_data = identity->get_encoding(identity);
-	identity_str = strndup(id_data.ptr, id_data.len);
-	if (!identity_str)
+	/* use the printable form: get_encoding() would return raw DER for
+	 * DN identities, which is no valid text lookup key */
+	written = snprintf(identity_str, sizeof(identity_str), "%Y", identity);
+	if (written < 0 || written >= (int)sizeof(identity_str))
 	{
+		DBG1(DBG_CFG, "dhcp-inform-db: identity too long for route lookup");
 		return 0;
 	}
 	at = strchr(identity_str, '@');
@@ -276,7 +356,6 @@ static int add_identity_routes(private_dhcp_inform_db_provider_t *this,
 	if (!enumerator)
 	{
 		DBG2(DBG_CFG, "dhcp-inform-db: v_user_routes not available");
-		free(identity_str);
 		return 0;
 	}
 
@@ -289,7 +368,7 @@ static int add_identity_routes(private_dhcp_inform_db_provider_t *this,
 			continue;
 		}
 
-		ts = resource_to_ts(resource_type, resource_value);
+		ts = resource_to_ts(this, resource_type, resource_value);
 		if (ts)
 		{
 			routes->insert_last(routes, ts);
@@ -305,7 +384,6 @@ static int add_identity_routes(private_dhcp_inform_db_provider_t *this,
 		DBG1(DBG_CFG, "dhcp-inform-db: found %d routes for identity %s",
 			 added, identity_str);
 	}
-	free(identity_str);
 
 	return added;
 }
@@ -434,9 +512,20 @@ METHOD(dhcp_inform_provider_t, is_available, bool,
 	return this->db != NULL;
 }
 
+/**
+ * Free an FQDN cache entry and its key
+ */
+static void fqdn_entry_destroy(void *val, const void *key)
+{
+	free(val);
+	free((void*)key);
+}
+
 METHOD(dhcp_inform_provider_t, destroy, void,
 	private_dhcp_inform_db_provider_t *this)
 {
+	this->fqdn_cache->destroy_function(this->fqdn_cache, fqdn_entry_destroy);
+	this->mutex->destroy(this->mutex);
 	DESTROY_IF(this->db);
 	free(this);
 }
@@ -458,6 +547,9 @@ dhcp_inform_db_provider_t *dhcp_inform_db_provider_create()
 				.destroy = _destroy,
 			},
 		},
+		.fqdn_cache = hashtable_create(hashtable_hash_str,
+									   hashtable_equals_str, 4),
+		.mutex = mutex_create(MUTEX_TYPE_DEFAULT),
 	);
 
 	/* Get database URI from configuration */

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -105,8 +105,8 @@ static traffic_selector_t *parse_cidr(const char *cidr)
 		return NULL;
 	}
 
+	/* the constructor adopts and destroys the host */
 	ts = traffic_selector_create_from_subnet(host, prefix, 0, 0, 65535);
-	host->destroy(host);
 
 	return ts;
 }

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -264,6 +264,55 @@ static job_requeue_t resolve_fqdn_job(fqdn_job_t *job)
 }
 
 /**
+ * Queue background resolutions for every fqdn resource already present in
+ * v_user_routes, so the cache is warm before the first DHCPINFORM arrives
+ * and cold names cost a route only when added to the database at runtime
+ */
+static void prewarm_fqdn_cache(private_dhcp_inform_db_provider_t *this)
+{
+	enumerator_t *enumerator;
+	fqdn_entry_t *entry;
+	fqdn_job_t *job;
+	char *fqdn;
+
+	enumerator = this->db->query(this->db,
+		"SELECT DISTINCT resource_value FROM v_user_routes "
+		"WHERE resource_type = 'fqdn'",
+		DB_TEXT);
+	if (!enumerator)
+	{
+		return;
+	}
+
+	while (enumerator->enumerate(enumerator, &fqdn))
+	{
+		if (!fqdn || !*fqdn)
+		{
+			continue;
+		}
+		this->mutex->lock(this->mutex);
+		entry = this->fqdn_cache->get(this->fqdn_cache, fqdn);
+		if (!entry)
+		{
+			INIT(entry,
+				.resolving = TRUE,
+			);
+			this->fqdn_cache->put(this->fqdn_cache, strdup(fqdn), entry);
+			INIT(job,
+				.provider = this,
+				.fqdn = strdup(fqdn),
+			);
+			lib->processor->queue_job(lib->processor,
+				(job_t*)callback_job_create(
+					(callback_job_cb_t)resolve_fqdn_job, job,
+					(void*)fqdn_job_destroy, callback_job_cancel_thread));
+		}
+		this->mutex->unlock(this->mutex);
+	}
+	enumerator->destroy(enumerator);
+}
+
+/**
  * Look an FQDN up in the cache, 0 when no address is known (yet).
  * The request path never resolves: a miss or a due refresh queues a
  * background job, and an expired entry keeps serving its last address
@@ -301,7 +350,8 @@ static uint32_t resolve_fqdn(private_dhcp_inform_db_provider_t *this,
 	{
 		lib->processor->queue_job(lib->processor,
 			(job_t*)callback_job_create((callback_job_cb_t)resolve_fqdn_job,
-										job, (void*)fqdn_job_destroy, NULL));
+										job, (void*)fqdn_job_destroy,
+										callback_job_cancel_thread));
 	}
 
 	return ip_addr;
@@ -621,6 +671,7 @@ dhcp_inform_db_provider_t *dhcp_inform_db_provider_create()
 		if (this->db)
 		{
 			DBG1(DBG_CFG, "dhcp-inform: database provider connected");
+			prewarm_fqdn_cache(this);
 		}
 		else
 		{

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -16,6 +16,7 @@
 #include <selectors/traffic_selector.h>
 #include <networking/host.h>
 #include <threading/mutex.h>
+#include <processing/jobs/callback_job.h>
 
 #include <string.h>
 #include <netdb.h>
@@ -27,16 +28,23 @@
  */
 #define FQDN_CACHE_TTL 300
 
+/**
+ * How long a failed resolution is remembered before retrying, in seconds
+ */
+#define FQDN_NEGATIVE_TTL 60
+
 typedef struct private_dhcp_inform_db_provider_t private_dhcp_inform_db_provider_t;
 
 /**
  * Cached FQDN resolution
  */
 typedef struct {
-	/** resolved address, network byte order */
+	/** resolved address, network byte order; 0 while unresolved or failed */
 	uint32_t addr;
-	/** monotonic expiry time */
+	/** monotonic time after which a refresh becomes due */
 	time_t expires;
+	/** a background resolution job is in flight */
+	bool resolving;
 } fqdn_entry_t;
 
 /**
@@ -191,38 +199,42 @@ static bool ip_in_subnet(host_t *ip, host_t *network, uint8_t prefix)
 }
 
 /**
- * Resolve an FQDN to an IPv4 address (network byte order), 0 on failure.
- * Successful resolutions are cached, so the synchronous getaddrinfo() call
- * hits the request path at most once per FQDN and TTL window.
+ * Data for a background FQDN resolution job. The provider outlives every
+ * queued job: the daemon cancels all processor jobs before plugins unload.
  */
-static uint32_t resolve_fqdn(private_dhcp_inform_db_provider_t *this,
-							 const char *fqdn)
+typedef struct {
+	/** provider owning the cache */
+	private_dhcp_inform_db_provider_t *provider;
+	/** name to resolve, owned */
+	char *fqdn;
+} fqdn_job_t;
+
+/**
+ * Destroy background resolution job data
+ */
+static void fqdn_job_destroy(fqdn_job_t *job)
 {
+	free(job->fqdn);
+	free(job);
+}
+
+/**
+ * Resolve an FQDN on a worker thread and store the outcome in the cache;
+ * failures are cached too, with a shorter TTL, so an unreachable resolver
+ * is retried at most once per window
+ */
+static job_requeue_t resolve_fqdn_job(fqdn_job_t *job)
+{
+	private_dhcp_inform_db_provider_t *this = job->provider;
 	struct addrinfo hints, *res;
 	fqdn_entry_t *entry;
 	uint32_t ip_addr = 0;
-	time_t now;
-
-	now = time_monotonic(NULL);
-
-	this->mutex->lock(this->mutex);
-	entry = this->fqdn_cache->get(this->fqdn_cache, (void*)fqdn);
-	if (entry && entry->expires > now)
-	{
-		ip_addr = entry->addr;
-	}
-	this->mutex->unlock(this->mutex);
-
-	if (ip_addr)
-	{
-		return ip_addr;
-	}
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_INET;
 	hints.ai_socktype = SOCK_STREAM;
 
-	if (getaddrinfo(fqdn, NULL, &hints, &res) == 0)
+	if (getaddrinfo(job->fqdn, NULL, &hints, &res) == 0)
 	{
 		if (res->ai_family == AF_INET)
 		{
@@ -230,24 +242,66 @@ static uint32_t resolve_fqdn(private_dhcp_inform_db_provider_t *this,
 			ip_addr = sin->sin_addr.s_addr;
 		}
 		freeaddrinfo(res);
+		DBG2(DBG_CFG, "dhcp-inform-db: resolved FQDN %s", job->fqdn);
 	}
 	else
 	{
-		DBG1(DBG_CFG, "dhcp-inform-db: failed to resolve FQDN: %s", fqdn);
+		DBG1(DBG_CFG, "dhcp-inform-db: failed to resolve FQDN: %s", job->fqdn);
 	}
 
-	if (ip_addr)
+	this->mutex->lock(this->mutex);
+	entry = this->fqdn_cache->get(this->fqdn_cache, job->fqdn);
+	if (entry)
 	{
-		this->mutex->lock(this->mutex);
-		entry = this->fqdn_cache->get(this->fqdn_cache, (void*)fqdn);
-		if (!entry)
-		{
-			INIT(entry);
-			this->fqdn_cache->put(this->fqdn_cache, strdup(fqdn), entry);
-		}
 		entry->addr = ip_addr;
-		entry->expires = now + FQDN_CACHE_TTL;
-		this->mutex->unlock(this->mutex);
+		entry->expires = time_monotonic(NULL) +
+						 (ip_addr ? FQDN_CACHE_TTL : FQDN_NEGATIVE_TTL);
+		entry->resolving = FALSE;
+	}
+	this->mutex->unlock(this->mutex);
+
+	return JOB_REQUEUE_NONE;
+}
+
+/**
+ * Look an FQDN up in the cache, 0 when no address is known (yet).
+ * The request path never resolves: a miss or a due refresh queues a
+ * background job, and an expired entry keeps serving its last address
+ * until the refresh lands, so routes never drop in steady state.
+ */
+static uint32_t resolve_fqdn(private_dhcp_inform_db_provider_t *this,
+							 const char *fqdn)
+{
+	fqdn_entry_t *entry;
+	fqdn_job_t *job = NULL;
+	uint32_t ip_addr = 0;
+	time_t now;
+
+	now = time_monotonic(NULL);
+
+	this->mutex->lock(this->mutex);
+	entry = this->fqdn_cache->get(this->fqdn_cache, (void*)fqdn);
+	if (!entry)
+	{
+		INIT(entry);
+		this->fqdn_cache->put(this->fqdn_cache, strdup(fqdn), entry);
+	}
+	ip_addr = entry->addr;
+	if (entry->expires <= now && !entry->resolving)
+	{
+		entry->resolving = TRUE;
+		INIT(job,
+			.provider = this,
+			.fqdn = strdup(fqdn),
+		);
+	}
+	this->mutex->unlock(this->mutex);
+
+	if (job)
+	{
+		lib->processor->queue_job(lib->processor,
+			(job_t*)callback_job_create((callback_job_cb_t)resolve_fqdn_job,
+										job, (void*)fqdn_job_destroy, NULL));
 	}
 
 	return ip_addr;

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -475,6 +475,12 @@ static uint32_t resolve_fqdn(private_dhcp_inform_db_provider_t *this,
 		this->fqdn_cache->put(this->fqdn_cache, strdup(fqdn), entry);
 	}
 	ip_addr = entry->addr;
+	if (ip_addr && now - entry->last_ok > FQDN_MAX_STALE)
+	{
+		/* the resolver has not succeeded within the stale bound, it may
+		 * be stuck behind a slow lookup: the bound holds on reads too */
+		ip_addr = 0;
+	}
 	if (entry->expires <= now && !entry->resolving)
 	{
 		entry->resolving = TRUE;

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.c
@@ -268,12 +268,18 @@ static job_requeue_t resolve_fqdn_job(fqdn_job_t *job)
  * v_user_routes, so the cache is warm before the first DHCPINFORM arrives
  * and cold names cost a route only when added to the database at runtime
  */
-static void prewarm_fqdn_cache(private_dhcp_inform_db_provider_t *this)
+METHOD(dhcp_inform_db_provider_t, prewarm, void,
+	private_dhcp_inform_db_provider_t *this)
 {
 	enumerator_t *enumerator;
 	fqdn_entry_t *entry;
 	fqdn_job_t *job;
 	char *fqdn;
+
+	if (!this->db)
+	{
+		return;
+	}
 
 	enumerator = this->db->query(this->db,
 		"SELECT DISTINCT resource_value FROM v_user_routes "
@@ -655,6 +661,7 @@ dhcp_inform_db_provider_t *dhcp_inform_db_provider_create()
 				.is_available = _is_available,
 				.destroy = _destroy,
 			},
+			.prewarm = _prewarm,
 		},
 		.fqdn_cache = hashtable_create(hashtable_hash_str,
 									   hashtable_equals_str, 4),
@@ -671,7 +678,6 @@ dhcp_inform_db_provider_t *dhcp_inform_db_provider_create()
 		if (this->db)
 		{
 			DBG1(DBG_CFG, "dhcp-inform: database provider connected");
-			prewarm_fqdn_cache(this);
 		}
 		else
 		{

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.h
@@ -50,6 +50,16 @@ struct dhcp_inform_db_provider_t {
 	 * @param this			provider instance
 	 */
 	void (*prewarm)(dhcp_inform_db_provider_t *this);
+
+	/**
+	 * Check whether identity routes can currently be served. When the
+	 * optional v_user_routes view is not queryable the identity path is
+	 * disabled for a recheck interval, then probed again: the view may be
+	 * created while the daemon runs.
+	 *
+	 * @return				TRUE if identity routes are available
+	 */
+	bool (*uses_identity)(dhcp_inform_db_provider_t *this);
 };
 
 /**

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_db_provider.h
@@ -41,6 +41,15 @@ struct dhcp_inform_db_provider_t {
 	 * Implements dhcp_inform_provider_t interface
 	 */
 	dhcp_inform_provider_t provider;
+
+	/**
+	 * Queue background resolution of the fqdn resources already in the
+	 * database. Call only once the owning responder can no longer fail
+	 * construction: the queued jobs reference this provider.
+	 *
+	 * @param this			provider instance
+	 */
+	void (*prewarm)(dhcp_inform_db_provider_t *this);
 };
 
 /**

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_plugin.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_plugin.c
@@ -101,10 +101,11 @@ PLUGIN_DEFINE(dhcp_inform)
 {
 	private_dhcp_inform_plugin_t *this;
 
-	if (!lib->caps->keep(lib->caps, CAP_NET_RAW))
+	if (!lib->caps->keep(lib->caps, CAP_NET_BIND_SERVICE))
 	{
-		/* Required for AF_PACKET socket to receive broadcasts */
-		DBG1(DBG_NET, "dhcp-inform plugin requires CAP_NET_RAW capability");
+		/* Required to bind the DHCP server port (67) */
+		DBG1(DBG_NET, "dhcp-inform plugin requires CAP_NET_BIND_SERVICE "
+			 "capability");
 		return NULL;
 	}
 

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_plugin.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_plugin.c
@@ -108,6 +108,16 @@ PLUGIN_DEFINE(dhcp_inform)
 			 "capability");
 		return NULL;
 	}
+	if (lib->settings->get_str(lib->settings,
+			"%s.plugins.dhcp-inform.interface", NULL, lib->ns) &&
+		!lib->caps->keep(lib->caps, CAP_NET_RAW))
+	{
+		/* SO_BINDTODEVICE on a non-loopback interface requires CAP_NET_RAW
+		 * even on a plain UDP socket */
+		DBG1(DBG_NET, "dhcp-inform plugin requires CAP_NET_RAW capability "
+			 "to bind to an interface");
+		return NULL;
+	}
 
 	INIT(this,
 		.public = {

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_provider.h
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_provider.h
@@ -16,6 +16,7 @@
 #define DHCP_INFORM_PROVIDER_H_
 
 #include <collections/linked_list.h>
+#include <utils/identification.h>
 
 typedef struct dhcp_inform_provider_t dhcp_inform_provider_t;
 
@@ -30,16 +31,19 @@ typedef struct dhcp_inform_provider_t dhcp_inform_provider_t;
 struct dhcp_inform_provider_t {
 
 	/**
-	 * Get routes for a client by virtual IP.
+	 * Get routes for a client by virtual IP and, when known, IKE identity.
 	 *
 	 * @param this			provider instance
 	 * @param client_ip		client's virtual IP address string
+	 * @param identity		client's IKE identity, NULL if no IKE_SA holds
+	 *						the virtual IP (providers may ignore it)
 	 * @return				linked_list_t of traffic_selector_t (caller destroys).
 	 *						Returns valid list (possibly empty) on success.
 	 *						NULL indicates allocation failure; callers must handle.
 	 */
 	linked_list_t* (*get_routes)(dhcp_inform_provider_t *this,
-								 const char *client_ip);
+								 const char *client_ip,
+								 identification_t *identity);
 
 	/**
 	 * Get provider name for logging.

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -198,9 +198,11 @@ static identification_t *find_identity_by_vip(uint32_t vip_addr)
 		{
 			if (vip->ip_equals(vip, ike_vip))
 			{
-				/* clone: the identification_t is owned by the IKE_SA and only
-				 * valid while the enumerator holds it */
-				identity = ike_sa->get_other_id(ike_sa);
+				/* prefer the authenticated EAP identity, it falls back to
+				 * the IKE identity for non-EAP peers; clone it, the
+				 * identification_t is owned by the IKE_SA and only valid
+				 * while the enumerator holds it */
+				identity = ike_sa->get_other_eap_id(ike_sa);
 				identity = identity->clone(identity);
 				break;
 			}
@@ -364,6 +366,13 @@ static chunk_t encode_classless_routes(linked_list_t *routes, uint32_t gateway)
 		host_t *net;
 		uint8_t prefix;
 
+		/* options 121/249 are IPv4-only; providers filter families, this
+		 * guards against any selector slipping through (e.g. from TS mode) */
+		if (ts->get_type(ts) != TS_IPV4_ADDR_RANGE)
+		{
+			continue;
+		}
+
 		ts->to_subnet(ts, &net, &prefix);
 		net->destroy(net);
 		route_len = 1 + ((prefix + 7) / 8) + 4;
@@ -398,6 +407,11 @@ static chunk_t encode_classless_routes(linked_list_t *routes, uint32_t gateway)
 		chunk_t net_chunk;
 		uint8_t prefix;
 		int subnet_bytes;
+
+		if (ts->get_type(ts) != TS_IPV4_ADDR_RANGE)
+		{
+			continue;
+		}
 
 		ts->to_subnet(ts, &net, &prefix);
 		net_chunk = net->get_address(net);
@@ -590,10 +604,44 @@ static void send_dhcp_ack(private_dhcp_inform_responder_t *this,
 	dest.sin_port = htons(DHCP_CLIENT_PORT);
 	dest.sin_addr.s_addr = client_ip;
 
-	if (sendto(this->fd, &ack, ack_len, 0,
-			   (struct sockaddr*)&dest, sizeof(dest)) < 0)
+	/* Pin the source to the configured server address via IP_PKTINFO: an
+	 * unconnected socket would take it from the route, which can disagree
+	 * with the DHCP server identifier and miss the IPsec policy */
+	struct iovec iov = {
+		.iov_base = &ack,
+		.iov_len = ack_len,
+	};
+	char cbuf[CMSG_SPACE(sizeof(struct in_pktinfo))] = {};
+	struct msghdr msg = {
+		.msg_name = &dest,
+		.msg_namelen = sizeof(dest),
+		.msg_iov = &iov,
+		.msg_iovlen = 1,
+		.msg_control = cbuf,
+		.msg_controllen = sizeof(cbuf),
+	};
+	struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+	struct in_pktinfo *pktinfo;
+
+	cmsg->cmsg_level = IPPROTO_IP;
+	cmsg->cmsg_type = IP_PKTINFO;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(struct in_pktinfo));
+	pktinfo = (struct in_pktinfo*)CMSG_DATA(cmsg);
+	pktinfo->ipi_spec_dst.s_addr = this->server_ip;
+
+	if (sendmsg(this->fd, &msg, 0) < 0)
 	{
-		DBG1(DBG_NET, "dhcp-inform: failed to send DHCPACK: %s", strerror(errno));
+		/* the pinned source only routes when the configured server address
+		 * is local; fall back to route-selected source otherwise */
+		DBG2(DBG_NET, "dhcp-inform: send with pinned source failed (%s), "
+			 "retrying with routed source", strerror(errno));
+		msg.msg_control = NULL;
+		msg.msg_controllen = 0;
+		if (sendmsg(this->fd, &msg, 0) < 0)
+		{
+			DBG1(DBG_NET, "dhcp-inform: failed to send DHCPACK: %s",
+				 strerror(errno));
+		}
 	}
 	else
 	{
@@ -711,7 +759,8 @@ CALLBACK(receive_dhcp, bool,
 }
 
 /**
- * Create the UDP socket receiving DHCPINFORM and sending replies
+ * Create the UDP socket receiving DHCPINFORM and sending replies.
+ * Returns the socket, or the negated errno of the failed operation.
  */
 static int create_dhcp_socket(const char *iface)
 {
@@ -720,14 +769,14 @@ static int create_dhcp_socket(const char *iface)
 		.sin_port = htons(DHCP_SERVER_PORT),
 		.sin_addr.s_addr = htonl(INADDR_ANY),
 	};
-	int fd, on = 1;
+	int fd, err, on = 1;
 
 	fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
 	if (fd < 0)
 	{
 		DBG1(DBG_NET, "dhcp-inform: failed to create socket: %s",
 			 strerror(errno));
-		return -1;
+		return -errno;
 	}
 
 	/* Sharing port 67 with a DHCP daemon works only when every socket sets
@@ -738,15 +787,17 @@ static int create_dhcp_socket(const char *iface)
 	{
 		DBG1(DBG_NET, "dhcp-inform: failed to set SO_REUSEADDR: %s",
 			 strerror(errno));
+		err = errno;
 		close(fd);
-		return -1;
+		return -err;
 	}
 	if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)) < 0)
 	{
 		DBG1(DBG_NET, "dhcp-inform: failed to set SO_REUSEPORT: %s",
 			 strerror(errno));
+		err = errno;
 		close(fd);
-		return -1;
+		return -err;
 	}
 
 	/* DHCPINFORM is typically sent to 255.255.255.255 */
@@ -754,8 +805,9 @@ static int create_dhcp_socket(const char *iface)
 	{
 		DBG1(DBG_NET, "dhcp-inform: failed to set SO_BROADCAST: %s",
 			 strerror(errno));
+		err = errno;
 		close(fd);
-		return -1;
+		return -err;
 	}
 
 	/* Optional: restrict to the VPN interface. Tunnelled packets are still
@@ -765,16 +817,18 @@ static int create_dhcp_socket(const char *iface)
 	{
 		DBG1(DBG_NET, "dhcp-inform: failed to bind to %s: %s",
 			 iface, strerror(errno));
+		err = errno;
 		close(fd);
-		return -1;
+		return -err;
 	}
 
 	if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
 	{
 		DBG1(DBG_NET, "dhcp-inform: failed to bind to port 67: %s",
 			 strerror(errno));
+		err = errno;
 		close(fd);
-		return -1;
+		return -err;
 	}
 
 	return fd;
@@ -902,6 +956,15 @@ dhcp_inform_responder_t *dhcp_inform_responder_create()
 
 	/* Create the UDP socket used for both directions */
 	this->fd = create_dhcp_socket(iface);
+	if (this->fd == -EADDRINUSE)
+	{
+		/* another DHCP daemon owns the port without SO_REUSEPORT; keep the
+		 * daemon running with the responder disabled instead of failing the
+		 * whole charon startup on such hosts */
+		DBG1(DBG_NET, "dhcp-inform: port 67 is taken by another process "
+			 "without SO_REUSEPORT, responder disabled");
+		return &this->public;
+	}
 	if (this->fd < 0)
 	{
 		destroy(this);

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -183,11 +183,13 @@ static identification_t *find_identity_by_vip(uint32_t vip_addr)
 		return NULL;
 	}
 
-	/* wait = FALSE: this runs on a processor worker servicing the DHCP
-	 * socket; skipping momentarily checked-out IKE_SAs only costs the
-	 * identity for one request, blocking on them could stall the worker */
+	/* wait = TRUE: skipping a momentarily checked-out IKE_SA would silently
+	 * drop its identity routes from an otherwise successful ACK, and the
+	 * client has no reason to ask again. This callback runs on its own
+	 * processor job, so the bounded wait for a checkout delays only further
+	 * DHCP datagrams, nothing else. */
 	enumerator = charon->controller->create_ike_sa_enumerator(
-						charon->controller, FALSE);
+						charon->controller, TRUE);
 	while (!identity && enumerator->enumerate(enumerator, &ike_sa))
 	{
 		enumerator_t *vip_enum;
@@ -493,12 +495,14 @@ static uint8_t *find_dhcp_option(dhcp_packet_t *pkt, size_t pkt_len,
 }
 
 /**
- * Get DHCP message type
+ * Get DHCP message type, 0 unless the option carries exactly one byte
  */
 static uint8_t get_dhcp_type(dhcp_packet_t *pkt, size_t pkt_len)
 {
-	uint8_t *type = find_dhcp_option(pkt, pkt_len, DHCP_OPT_MESSAGE_TYPE, NULL);
-	return type ? *type : 0;
+	uint8_t *type, type_len = 0;
+
+	type = find_dhcp_option(pkt, pkt_len, DHCP_OPT_MESSAGE_TYPE, &type_len);
+	return (type && type_len == 1) ? *type : 0;
 }
 
 /**
@@ -750,13 +754,16 @@ CALLBACK(receive_dhcp, bool,
 	private_dhcp_inform_responder_t *this, int fd, watcher_event_t event)
 {
 	dhcp_packet_t packet;
+	struct sockaddr_in src;
+	socklen_t src_len = sizeof(src);
 	ssize_t len;
 
 	/* Zero so option parsing never walks uninitialized tail bytes when the
 	 * client sends less than the full options capacity */
 	memset(&packet, 0, sizeof(packet));
 
-	len = recvfrom(fd, &packet, sizeof(packet), MSG_DONTWAIT, NULL, NULL);
+	len = recvfrom(fd, &packet, sizeof(packet), MSG_DONTWAIT,
+				   (struct sockaddr*)&src, &src_len);
 
 	if (len < 0)
 	{
@@ -764,6 +771,22 @@ CALLBACK(receive_dhcp, bool,
 		{
 			DBG1(DBG_NET, "dhcp-inform: recvfrom failed: %s", strerror(errno));
 		}
+		return TRUE;
+	}
+
+	/* Trust ciaddr only when it matches the actual sender: the wildcard
+	 * bind is reachable beyond the VPN, and a spoofed ciaddr would
+	 * otherwise trigger SA scans, database queries and misdirected ACKs */
+	if (src_len < sizeof(src) || src.sin_family != AF_INET ||
+		src.sin_port != htons(DHCP_CLIENT_PORT) ||
+		(len >= (ssize_t)DHCP_MIN_MSG_SIZE &&
+		 src.sin_addr.s_addr != packet.ciaddr))
+	{
+		char src_str[INET_ADDRSTRLEN];
+
+		inet_ntop(AF_INET, &src.sin_addr, src_str, sizeof(src_str));
+		DBG2(DBG_NET, "dhcp-inform: dropping datagram with unexpected "
+			 "sender %s:%u", src_str, ntohs(src.sin_port));
 		return TRUE;
 	}
 
@@ -793,21 +816,14 @@ static int create_dhcp_socket(const char *iface)
 		return -errno;
 	}
 
-	/* Sharing port 67 with a DHCP daemon works only when every socket sets
-	 * SO_REUSEPORT; a daemon bound without it makes our bind fail with
-	 * EADDRINUSE. SO_REUSEADDR alone does not permit a second UDP bind on
-	 * the same address, but keeps rebinding painless after restarts. */
+	/* The port is owned exclusively: SO_REUSEPORT would make the kernel
+	 * load-balance unicast port-67 flows across the reuse group, silently
+	 * stealing renewals from a co-located DHCP daemon. If another daemon
+	 * owns the port, bind fails and the responder starts disabled instead.
+	 * SO_REUSEADDR just keeps rebinding painless after restarts. */
 	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0)
 	{
 		DBG1(DBG_NET, "dhcp-inform: failed to set SO_REUSEADDR: %s",
-			 strerror(errno));
-		err = errno;
-		close(fd);
-		return -err;
-	}
-	if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)) < 0)
-	{
-		DBG1(DBG_NET, "dhcp-inform: failed to set SO_REUSEPORT: %s",
 			 strerror(errno));
 		err = errno;
 		close(fd);
@@ -975,8 +991,8 @@ dhcp_inform_responder_t *dhcp_inform_responder_create()
 		/* another DHCP daemon owns the port without SO_REUSEPORT; keep the
 		 * daemon running with the responder disabled instead of failing the
 		 * whole charon startup on such hosts */
-		DBG1(DBG_NET, "dhcp-inform: port 67 is taken by another process "
-			 "without SO_REUSEPORT, responder disabled");
+		DBG1(DBG_NET, "dhcp-inform: port 67 is taken by another process, "
+			 "responder disabled");
 		return &this->public;
 	}
 	if (this->fd < 0)

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -999,7 +999,12 @@ dhcp_inform_responder_t *dhcp_inform_responder_create()
 					  receive_dhcp, this);
 
 	/* Warm the FQDN cache only now: construction cannot fail anymore, so
-	 * the queued background jobs cannot outlive the provider they use */
+	 * the queued background jobs cannot outlive the provider they use.
+	 * Warming is asynchronous by design and startup never waits for DNS:
+	 * an INFORM racing the very first resolutions at worst gets an ACK
+	 * without an FQDN route, and the client's next periodic INFORM fills
+	 * it in. Delaying the ACK instead would risk the client's retransmit
+	 * timeout, losing ALL routes for that exchange. */
 	if (this->db_provider)
 	{
 		this->db_provider->prewarm(this->db_provider);

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -333,9 +333,14 @@ static linked_list_t *get_routes_for_client(private_dhcp_inform_responder_t *thi
 
 		DBG1(DBG_NET, "dhcp-inform: using database routes mode (exclusive)");
 		/* The SA scan runs only here: the database provider is the sole
-		 * identity consumer, and this branch means it is the selected
-		 * route source, not merely an unused fallback */
-		identity = find_identity_by_vip(ciaddr);
+		 * identity consumer, this branch means it is the selected route
+		 * source, and a pool-only schema without v_user_routes never pays
+		 * for a lookup it cannot use */
+		identity = NULL;
+		if (this->db_provider->uses_identity(this->db_provider))
+		{
+			identity = find_identity_by_vip(ciaddr);
+		}
 		if (identity)
 		{
 			DBG1(DBG_NET, "dhcp-inform: client %s identified as %Y",
@@ -837,7 +842,12 @@ static int create_dhcp_socket(const char *iface)
 	}
 
 	/* Optional: restrict to the VPN interface. Tunnelled packets are still
-	 * delivered, they surface on the interface carrying the ESP traffic. */
+	 * delivered, they surface on the interface carrying the ESP traffic.
+	 * The binding applies to the whole socket, so ACKs also egress here:
+	 * an rx-only device filter does not exist for UDP, and a second port-67
+	 * send socket would need address reuse, reopening the flow-diversion
+	 * hole that exclusive ownership closes. Asymmetrically routed gateways
+	 * should leave the option unset and let routing pick the egress. */
 	if (iface && setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, iface,
 							strlen(iface)) < 0)
 	{

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -183,8 +183,11 @@ static identification_t *find_identity_by_vip(uint32_t vip_addr)
 		return NULL;
 	}
 
+	/* wait = FALSE: this runs on a processor worker servicing the DHCP
+	 * socket; skipping momentarily checked-out IKE_SAs only costs the
+	 * identity for one request, blocking on them could stall the worker */
 	enumerator = charon->controller->create_ike_sa_enumerator(
-						charon->controller, TRUE);
+						charon->controller, FALSE);
 	while (!identity && enumerator->enumerate(enumerator, &ike_sa))
 	{
 		enumerator_t *vip_enum;
@@ -452,6 +455,11 @@ static uint8_t *find_dhcp_option(dhcp_packet_t *pkt, size_t pkt_len,
 		}
 		if (*opt == code)
 		{
+			/* reject options whose payload extends past the received data */
+			if (opt + 2 + opt[1] > end)
+			{
+				break;
+			}
 			if (len)
 			{
 				*len = opt[1];
@@ -722,10 +730,20 @@ static int create_dhcp_socket(const char *iface)
 		return -1;
 	}
 
-	/* Coexist with a DHCP daemon serving the physical segment */
+	/* Sharing port 67 with a DHCP daemon works only when every socket sets
+	 * SO_REUSEPORT; a daemon bound without it makes our bind fail with
+	 * EADDRINUSE. SO_REUSEADDR alone does not permit a second UDP bind on
+	 * the same address, but keeps rebinding painless after restarts. */
 	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0)
 	{
 		DBG1(DBG_NET, "dhcp-inform: failed to set SO_REUSEADDR: %s",
+			 strerror(errno));
+		close(fd);
+		return -1;
+	}
+	if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)) < 0)
+	{
+		DBG1(DBG_NET, "dhcp-inform: failed to set SO_REUSEPORT: %s",
 			 strerror(errno));
 		close(fd);
 		return -1;

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -288,7 +288,7 @@ static void add_routes_from_provider(dhcp_inform_provider_t *provider,
  */
 static linked_list_t *get_routes_for_client(private_dhcp_inform_responder_t *this,
 											const char *client_ip,
-											identification_t *identity)
+											uint32_t ciaddr)
 {
 	linked_list_t *routes;
 	dhcp_inform_provider_t *ts_prov, *db_prov, *static_prov;
@@ -320,7 +320,7 @@ static linked_list_t *get_routes_for_client(private_dhcp_inform_responder_t *thi
 	if (ts_prov && ts_prov->is_available(ts_prov))
 	{
 		DBG1(DBG_NET, "dhcp-inform: using TS routes mode (exclusive)");
-		add_routes_from_provider(ts_prov, client_ip, identity, routes);
+		add_routes_from_provider(ts_prov, client_ip, NULL, routes);
 		DBG1(DBG_NET, "dhcp-inform: found %d routes from TS for %s",
 			 routes->get_count(routes), client_ip);
 		return routes;
@@ -329,8 +329,25 @@ static linked_list_t *get_routes_for_client(private_dhcp_inform_responder_t *thi
 	/* MODE 2: Database routes (exclusive) */
 	if (db_prov && db_prov->is_available(db_prov))
 	{
+		identification_t *identity;
+
 		DBG1(DBG_NET, "dhcp-inform: using database routes mode (exclusive)");
+		/* The SA scan runs only here: the database provider is the sole
+		 * identity consumer, and this branch means it is the selected
+		 * route source, not merely an unused fallback */
+		identity = find_identity_by_vip(ciaddr);
+		if (identity)
+		{
+			DBG1(DBG_NET, "dhcp-inform: client %s identified as %Y",
+				 client_ip, identity);
+		}
+		else
+		{
+			DBG2(DBG_NET, "dhcp-inform: no IKE_SA found for client %s",
+				 client_ip);
+		}
 		add_routes_from_provider(db_prov, client_ip, identity, routes);
+		DESTROY_IF(identity);
 		DBG1(DBG_NET, "dhcp-inform: found %d routes from DB for %s",
 			 routes->get_count(routes), client_ip);
 		return routes;
@@ -340,7 +357,7 @@ static linked_list_t *get_routes_for_client(private_dhcp_inform_responder_t *thi
 	if (static_prov && static_prov->is_available(static_prov))
 	{
 		DBG1(DBG_NET, "dhcp-inform: using static routes mode (exclusive)");
-		add_routes_from_provider(static_prov, client_ip, identity, routes);
+		add_routes_from_provider(static_prov, client_ip, NULL, routes);
 		DBG1(DBG_NET, "dhcp-inform: found %d routes from config for %s",
 			 routes->get_count(routes), client_ip);
 		return routes;
@@ -678,7 +695,6 @@ static void process_dhcp_packet(private_dhcp_inform_responder_t *this,
 								dhcp_packet_t *dhcp, size_t len)
 {
 	linked_list_t *routes;
-	identification_t *identity;
 	char client_ip_str[INET_ADDRSTRLEN];
 
 	if (len < DHCP_MIN_MSG_SIZE)
@@ -708,34 +724,14 @@ static void process_dhcp_packet(private_dhcp_inform_responder_t *this,
 	inet_ntop(AF_INET, &dhcp->ciaddr, client_ip_str, sizeof(client_ip_str));
 	DBG1(DBG_NET, "dhcp-inform: received DHCPINFORM from %s", client_ip_str);
 
-	/* Identify the peer holding this virtual IP; only the database
-	 * provider consumes the identity, so skip the SA scan entirely when
-	 * it cannot serve */
-	identity = NULL;
-	if (this->db_provider &&
-		this->db_provider->provider.is_available(&this->db_provider->provider))
-	{
-		identity = find_identity_by_vip(dhcp->ciaddr);
-	}
-	if (identity)
-	{
-		DBG1(DBG_NET, "dhcp-inform: client %s identified as %Y",
-			 client_ip_str, identity);
-	}
-	else
-	{
-		DBG2(DBG_NET, "dhcp-inform: no IKE_SA found for client %s",
-			 client_ip_str);
-	}
-
-	/* Get routes from providers (mutually exclusive: TS OR DB OR static) */
-	routes = get_routes_for_client(this, client_ip_str, identity);
+	/* Get routes from providers (mutually exclusive: TS OR DB OR static);
+	 * the identity lookup happens inside, only for the mode that uses it */
+	routes = get_routes_for_client(this, client_ip_str, dhcp->ciaddr);
 
 	if (!routes)
 	{
 		DBG1(DBG_NET, "dhcp-inform: CRITICAL - failed to get routes list for %s",
 			 client_ip_str);
-		DESTROY_IF(identity);
 		return;
 	}
 
@@ -751,7 +747,6 @@ static void process_dhcp_packet(private_dhcp_inform_responder_t *this,
 	}
 
 	routes->destroy_offset(routes, offsetof(traffic_selector_t, destroy));
-	DESTROY_IF(identity);
 }
 
 /**

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -548,8 +548,9 @@ static void send_dhcp_ack(private_dhcp_inform_responder_t *this,
 	ack.hlen = request->hlen;
 	ack.xid = request->xid;
 	ack.ciaddr = client_ip;
-	ack.yiaddr = client_ip;
-	ack.siaddr = this->server_ip;
+	/* RFC 2131 4.3.5: an ACK answering INFORM assigns nothing, so yiaddr
+	 * stays zero, and siaddr names a bootstrap next-server, not us: the
+	 * server identity travels in option 54 only */
 	memcpy(ack.chaddr, request->chaddr, 16);
 	ack.magic = htonl(DHCP_MAGIC_COOKIE);
 

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -997,21 +997,24 @@ dhcp_inform_responder_t *dhcp_inform_responder_create()
 		return NULL;
 	}
 
-	/* Register with watcher */
-	lib->watcher->add(lib->watcher, this->fd, WATCHER_READ,
-					  receive_dhcp, this);
-
 	/* Warm the FQDN cache only now: construction cannot fail anymore, so
 	 * the queued background jobs cannot outlive the provider they use.
-	 * Warming is asynchronous by design and startup never waits for DNS:
-	 * an INFORM racing the very first resolutions at worst gets an ACK
-	 * without an FQDN route, and the client's next periodic INFORM fills
-	 * it in. Delaying the ACK instead would risk the client's retransmit
-	 * timeout, losing ALL routes for that exchange. */
+	 * The database enumeration below is synchronous and must finish before
+	 * the watcher can dispatch an INFORM: SQLite in multi-thread builds
+	 * forbids concurrent use of one connection and the driver only locks
+	 * for serialized builds. DNS warming stays asynchronous: an INFORM
+	 * racing the first resolutions at worst gets an ACK without an FQDN
+	 * route, and the client's next periodic INFORM fills it in; delaying
+	 * the ACK instead would risk the client's retransmit timeout, losing
+	 * ALL routes for that exchange. */
 	if (this->db_provider)
 	{
 		this->db_provider->prewarm(this->db_provider);
 	}
+
+	/* Register with watcher */
+	lib->watcher->add(lib->watcher, this->fd, WATCHER_READ,
+					  receive_dhcp, this);
 
 	DBG1(DBG_NET, "dhcp-inform: responder started on %s (%s)",
 		 iface ?: "all", server_ip);

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -349,9 +349,11 @@ static linked_list_t *get_routes_for_client(private_dhcp_inform_responder_t *thi
 }
 
 /**
- * Encode routes as DHCP option 121/249 format
+ * Encode routes as DHCP option 121/249 format, truncating at max_len so the
+ * result always fits the space the caller has left for both option copies
  */
-static chunk_t encode_classless_routes(linked_list_t *routes, uint32_t gateway)
+static chunk_t encode_classless_routes(linked_list_t *routes, uint32_t gateway,
+									   size_t max_len)
 {
 	chunk_t encoded;
 	enumerator_t *enumerator;
@@ -376,10 +378,10 @@ static chunk_t encode_classless_routes(linked_list_t *routes, uint32_t gateway)
 		ts->to_subnet(ts, &net, &prefix);
 		net->destroy(net);
 		route_len = 1 + ((prefix + 7) / 8) + 4;
-		/* Check for overflow (max DHCP option is 255 bytes anyway) */
-		if (total_len + route_len > 255)
+		if (total_len + route_len > max_len)
 		{
-			DBG1(DBG_NET, "dhcp-inform: routes exceed maximum option size");
+			DBG1(DBG_NET, "dhcp-inform: truncating routes to the %zu bytes "
+				 "the DHCP options can carry", max_len);
 			break;
 		}
 		total_len += route_len;
@@ -515,6 +517,7 @@ static void send_dhcp_ack(private_dhcp_inform_responder_t *this,
 	struct sockaddr_in dest;
 	size_t ack_len;
 	size_t required_space;
+	size_t routes_max;
 
 	memset(&ack, 0, sizeof(ack));
 
@@ -552,10 +555,21 @@ static void send_dhcp_ack(private_dhcp_inform_responder_t *this,
 		opt += 4;
 	}
 
-	/* Encode routes with server_ip as gateway */
-	routes_encoded = encode_classless_routes(routes, this->server_ip);
+	/* Encode routes with server_ip as gateway, capped to the space that
+	 * remains for TWO option copies (2-byte headers each) plus END, and to
+	 * the 255-byte single-option maximum */
+	if (opt + 5 < opt_end)
+	{
+		routes_max = min((size_t)(opt_end - opt - 5) / 2, (size_t)255);
+	}
+	else
+	{
+		routes_max = 0;
+	}
+	routes_encoded = encode_classless_routes(routes, this->server_ip,
+											 routes_max);
 
-	if (routes_encoded.len > 0 && routes_encoded.len <= 255)
+	if (routes_encoded.len > 0)
 	{
 		/* Calculate required space: 2 options * (2 byte header + data) + END */
 		required_space = 2 * (2 + routes_encoded.len) + 1;

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -183,13 +183,13 @@ static identification_t *find_identity_by_vip(uint32_t vip_addr)
 		return NULL;
 	}
 
-	/* wait = TRUE: skipping a momentarily checked-out IKE_SA would silently
-	 * drop its identity routes from an otherwise successful ACK, and the
-	 * client has no reason to ask again. This callback runs on its own
-	 * processor job, so the bounded wait for a checkout delays only further
-	 * DHCP datagrams, nothing else. */
+	/* wait = FALSE: the manager's wait for a checked-out IKE_SA is
+	 * unbounded and the enumerator visits every SA, so waiting would let
+	 * a single SA stuck in a long operation anywhere on the daemon stall
+	 * all DHCP service. Skipping a busy SA at worst costs this exchange
+	 * its identity routes; the client's next INFORM refreshes them. */
 	enumerator = charon->controller->create_ike_sa_enumerator(
-						charon->controller, TRUE);
+						charon->controller, FALSE);
 	while (!identity && enumerator->enumerate(enumerator, &ike_sa))
 	{
 		enumerator_t *vip_enum;
@@ -708,8 +708,15 @@ static void process_dhcp_packet(private_dhcp_inform_responder_t *this,
 	inet_ntop(AF_INET, &dhcp->ciaddr, client_ip_str, sizeof(client_ip_str));
 	DBG1(DBG_NET, "dhcp-inform: received DHCPINFORM from %s", client_ip_str);
 
-	/* Identify the peer holding this virtual IP, if any */
-	identity = find_identity_by_vip(dhcp->ciaddr);
+	/* Identify the peer holding this virtual IP; only the database
+	 * provider consumes the identity, so skip the SA scan entirely when
+	 * it cannot serve */
+	identity = NULL;
+	if (this->db_provider &&
+		this->db_provider->provider.is_available(&this->db_provider->provider))
+	{
+		identity = find_identity_by_vip(dhcp->ciaddr);
+	}
 	if (identity)
 	{
 		DBG1(DBG_NET, "dhcp-inform: client %s identified as %Y",

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -2,7 +2,11 @@
  * Copyright (C) 2025 Structured World Foundation
  *
  * DHCP Inform Responder - responds to Windows DHCPINFORM with routes.
- * Uses packet socket like forecast plugin to catch broadcast from VPN tunnels.
+ *
+ * Receives over a plain UDP socket bound to port 67: the kernel delivers
+ * datagrams there after IP processing, so DHCPINFORM works both off the
+ * wire and as xfrm-decapsulated tunnel payload from road-warrior clients
+ * (a device-level packet socket never sees the tunnelled case).
  *
  * Route sources (in priority order):
  * 1. Traffic Selectors (EXCLUSIVE - when enabled, only TS routes are used)
@@ -22,25 +26,15 @@
 #include "dhcp_inform_static_provider.h"
 
 #include <daemon.h>
-#include <threading/thread.h>
-#include <processing/jobs/callback_job.h>
 #include <collections/linked_list.h>
 
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
 #include <netinet/in.h>
-#include <netinet/ip.h>
-#include <netinet/udp.h>
 #include <sys/socket.h>
-#include <sys/ioctl.h>
 #include <net/if.h>
-#include <linux/filter.h>
-#include <linux/if_packet.h>
-#include <linux/if_ether.h>
 #include <arpa/inet.h>
-#include <netdb.h>
-#include <ifaddrs.h>
 
 /* DHCP constants */
 #define DHCP_SERVER_PORT 67
@@ -72,9 +66,6 @@
 #define DHCP_OPT_CLASSLESS_ROUTES     121  /* RFC 3442 */
 #define DHCP_OPT_MS_CLASSLESS_ROUTES  249  /* Microsoft */
 #define DHCP_OPT_END           255
-
-/* Standard IP TTL for locally-generated packets */
-#define IP_DEFAULT_TTL         64
 
 /* Minimum DHCP message size (excluding options): op through magic = 236 bytes + 4 for options */
 #define DHCP_MIN_MSG_SIZE      240
@@ -127,22 +118,13 @@ struct private_dhcp_inform_responder_t {
 	dhcp_inform_static_provider_t *static_provider;
 
 	/**
-	 * Packet socket for receiving broadcasts (AF_PACKET)
+	 * UDP socket bound to the DHCP server port, used both to receive
+	 * DHCPINFORM and to send the DHCPACK reply
 	 */
-	int pkt_fd;
+	int fd;
 
 	/**
-	 * Raw socket for sending unicast responses (AF_INET, SOCK_RAW)
-	 */
-	int raw_fd;
-
-	/**
-	 * Interface index
-	 */
-	int ifindex;
-
-	/**
-	 * VPN interface name
+	 * VPN interface name (socket is bound to it when configured)
 	 */
 	char *iface;
 
@@ -181,10 +163,59 @@ static bool route_exists_in_list(linked_list_t *list, traffic_selector_t *ts)
 }
 
 /**
+ * Find the IKE identity of the peer holding the given virtual IP.
+ * Returns a clone the caller must destroy, NULL if no IKE_SA matches.
+ */
+static identification_t *find_identity_by_vip(uint32_t vip_addr)
+{
+	identification_t *identity = NULL;
+	enumerator_t *enumerator;
+	ike_sa_t *ike_sa;
+	host_t *vip;
+	struct sockaddr_in addr = {
+		.sin_family = AF_INET,
+		.sin_addr.s_addr = vip_addr,
+	};
+
+	vip = host_create_from_sockaddr((sockaddr_t*)&addr);
+	if (!vip)
+	{
+		return NULL;
+	}
+
+	enumerator = charon->controller->create_ike_sa_enumerator(
+						charon->controller, TRUE);
+	while (!identity && enumerator->enumerate(enumerator, &ike_sa))
+	{
+		enumerator_t *vip_enum;
+		host_t *ike_vip;
+
+		vip_enum = ike_sa->create_virtual_ip_enumerator(ike_sa, FALSE);
+		while (vip_enum->enumerate(vip_enum, &ike_vip))
+		{
+			if (vip->ip_equals(vip, ike_vip))
+			{
+				/* clone: the identification_t is owned by the IKE_SA and only
+				 * valid while the enumerator holds it */
+				identity = ike_sa->get_other_id(ike_sa);
+				identity = identity->clone(identity);
+				break;
+			}
+		}
+		vip_enum->destroy(vip_enum);
+	}
+	enumerator->destroy(enumerator);
+	vip->destroy(vip);
+
+	return identity;
+}
+
+/**
  * Add routes from provider to list with deduplication
  */
 static void add_routes_from_provider(dhcp_inform_provider_t *provider,
 									 const char *client_ip,
+									 identification_t *identity,
 									 linked_list_t *routes)
 {
 	linked_list_t *provider_routes;
@@ -198,7 +229,7 @@ static void add_routes_from_provider(dhcp_inform_provider_t *provider,
 		return;
 	}
 
-	provider_routes = provider->get_routes(provider, client_ip);
+	provider_routes = provider->get_routes(provider, client_ip, identity);
 	if (!provider_routes)
 	{
 		return;
@@ -249,7 +280,8 @@ static void add_routes_from_provider(dhcp_inform_provider_t *provider,
  * for graceful fallback - highest-priority available source is selected.
  */
 static linked_list_t *get_routes_for_client(private_dhcp_inform_responder_t *this,
-											const char *client_ip)
+											const char *client_ip,
+											identification_t *identity)
 {
 	linked_list_t *routes;
 	dhcp_inform_provider_t *ts_prov, *db_prov, *static_prov;
@@ -281,7 +313,7 @@ static linked_list_t *get_routes_for_client(private_dhcp_inform_responder_t *thi
 	if (ts_prov && ts_prov->is_available(ts_prov))
 	{
 		DBG1(DBG_NET, "dhcp-inform: using TS routes mode (exclusive)");
-		add_routes_from_provider(ts_prov, client_ip, routes);
+		add_routes_from_provider(ts_prov, client_ip, identity, routes);
 		DBG1(DBG_NET, "dhcp-inform: found %d routes from TS for %s",
 			 routes->get_count(routes), client_ip);
 		return routes;
@@ -291,7 +323,7 @@ static linked_list_t *get_routes_for_client(private_dhcp_inform_responder_t *thi
 	if (db_prov && db_prov->is_available(db_prov))
 	{
 		DBG1(DBG_NET, "dhcp-inform: using database routes mode (exclusive)");
-		add_routes_from_provider(db_prov, client_ip, routes);
+		add_routes_from_provider(db_prov, client_ip, identity, routes);
 		DBG1(DBG_NET, "dhcp-inform: found %d routes from DB for %s",
 			 routes->get_count(routes), client_ip);
 		return routes;
@@ -301,7 +333,7 @@ static linked_list_t *get_routes_for_client(private_dhcp_inform_responder_t *thi
 	if (static_prov && static_prov->is_available(static_prov))
 	{
 		DBG1(DBG_NET, "dhcp-inform: using static routes mode (exclusive)");
-		add_routes_from_provider(static_prov, client_ip, routes);
+		add_routes_from_provider(static_prov, client_ip, identity, routes);
 		DBG1(DBG_NET, "dhcp-inform: found %d routes from config for %s",
 			 routes->get_count(routes), client_ip);
 		return routes;
@@ -397,12 +429,15 @@ static chunk_t encode_classless_routes(linked_list_t *routes, uint32_t gateway)
 }
 
 /**
- * Find DHCP option in packet
+ * Find DHCP option in packet, parsing only the actually received bytes:
+ * clients commonly send the 300-byte BOOTP minimum, less than the full
+ * options capacity of dhcp_packet_t
  */
-static uint8_t *find_dhcp_option(dhcp_packet_t *pkt, uint8_t code, uint8_t *len)
+static uint8_t *find_dhcp_option(dhcp_packet_t *pkt, size_t pkt_len,
+								 uint8_t code, uint8_t *len)
 {
 	uint8_t *opt = pkt->options;
-	uint8_t *end = pkt->options + sizeof(pkt->options);
+	uint8_t *end = (uint8_t*)pkt + min(pkt_len, sizeof(*pkt));
 
 	while (opt < end && *opt != DHCP_OPT_END)
 	{
@@ -436,114 +471,44 @@ static uint8_t *find_dhcp_option(dhcp_packet_t *pkt, uint8_t code, uint8_t *len)
 /**
  * Get DHCP message type
  */
-static uint8_t get_dhcp_type(dhcp_packet_t *pkt)
+static uint8_t get_dhcp_type(dhcp_packet_t *pkt, size_t pkt_len)
 {
-	uint8_t *type = find_dhcp_option(pkt, DHCP_OPT_MESSAGE_TYPE, NULL);
+	uint8_t *type = find_dhcp_option(pkt, pkt_len, DHCP_OPT_MESSAGE_TYPE, NULL);
 	return type ? *type : 0;
 }
 
 /**
- * Calculate IP checksum
- */
-static uint16_t ip_checksum(void *data, size_t len)
-{
-	uint32_t sum = 0;
-	uint16_t *ptr = data;
-
-	while (len > 1)
-	{
-		sum += *ptr++;
-		len -= 2;
-	}
-	if (len == 1)
-	{
-		sum += *(uint8_t*)ptr;
-	}
-
-	while (sum >> 16)
-	{
-		sum = (sum & 0xFFFF) + (sum >> 16);
-	}
-
-	return ~sum;
-}
-
-/**
- * Calculate UDP checksum with pseudo-header
- */
-static uint16_t udp_checksum(uint32_t src, uint32_t dst,
-							 void *data, size_t len)
-{
-	uint32_t sum = 0;
-	uint16_t *ptr;
-
-	/* Pseudo-header */
-	sum += (src >> 16) & 0xFFFF;
-	sum += src & 0xFFFF;
-	sum += (dst >> 16) & 0xFFFF;
-	sum += dst & 0xFFFF;
-	sum += htons(IPPROTO_UDP);
-	sum += htons(len);
-
-	/* UDP header + data */
-	ptr = (uint16_t*)data;
-	while (len > 1)
-	{
-		sum += *ptr++;
-		len -= 2;
-	}
-	if (len == 1)
-	{
-		sum += *(uint8_t*)ptr;
-	}
-
-	while (sum >> 16)
-	{
-		sum = (sum & 0xFFFF) + (sum >> 16);
-	}
-
-	return ~sum;
-}
-
-/**
- * IP ID counter for packet identification (atomic increment for thread safety)
- */
-static uint32_t ip_id_counter = 0;
-
-/**
- * Send DHCPACK response via raw socket
+ * Send DHCPACK response, unicast to the client's address over the same
+ * UDP socket the request arrived on; the kernel routes it back through
+ * the IPsec policy like any other datagram
  */
 static void send_dhcp_ack(private_dhcp_inform_responder_t *this,
 						  dhcp_packet_t *request, linked_list_t *routes,
 						  uint32_t client_ip)
 {
-	struct __attribute__((packed)) {
-		struct iphdr ip;
-		struct udphdr udp;
-		dhcp_packet_t dhcp;
-	} pkt;
+	dhcp_packet_t ack;
 	uint8_t *opt;
 	uint8_t *opt_end;
 	chunk_t routes_encoded = chunk_empty;
 	struct sockaddr_in dest;
-	size_t dhcp_len, udp_len, total_len;
+	size_t ack_len;
 	size_t required_space;
 
-	memset(&pkt, 0, sizeof(pkt));
+	memset(&ack, 0, sizeof(ack));
 
 	/* Build DHCP response */
-	pkt.dhcp.op = 2;  /* BOOTREPLY */
-	pkt.dhcp.htype = request->htype;
-	pkt.dhcp.hlen = request->hlen;
-	pkt.dhcp.xid = request->xid;
-	pkt.dhcp.ciaddr = client_ip;
-	pkt.dhcp.yiaddr = client_ip;
-	pkt.dhcp.siaddr = this->server_ip;
-	memcpy(pkt.dhcp.chaddr, request->chaddr, 16);
-	pkt.dhcp.magic = htonl(DHCP_MAGIC_COOKIE);
+	ack.op = 2;  /* BOOTREPLY */
+	ack.htype = request->htype;
+	ack.hlen = request->hlen;
+	ack.xid = request->xid;
+	ack.ciaddr = client_ip;
+	ack.yiaddr = client_ip;
+	ack.siaddr = this->server_ip;
+	memcpy(ack.chaddr, request->chaddr, 16);
+	ack.magic = htonl(DHCP_MAGIC_COOKIE);
 
-	opt = pkt.dhcp.options;
-	opt_end = pkt.dhcp.options + sizeof(pkt.dhcp.options);
+	opt = ack.options;
+	opt_end = ack.options + sizeof(ack.options);
 
 	/* Message Type = DHCPACK */
 	*opt++ = DHCP_OPT_MESSAGE_TYPE;
@@ -608,38 +573,16 @@ static void send_dhcp_ack(private_dhcp_inform_responder_t *this,
 		return;
 	}
 
-	/* Calculate lengths */
-	dhcp_len = sizeof(dhcp_packet_t);
-	udp_len = sizeof(struct udphdr) + dhcp_len;
-	total_len = sizeof(struct iphdr) + udp_len;
+	/* Send only the used part of the message, never less than the
+	 * 300-byte BOOTP minimum some clients insist on */
+	ack_len = max((size_t)(opt - (uint8_t*)&ack), (size_t)300);
 
-	/* Build IP header */
-	pkt.ip.version = 4;
-	pkt.ip.ihl = 5;
-	pkt.ip.tos = 0;
-	pkt.ip.tot_len = htons(total_len);
-	pkt.ip.id = htons(__sync_fetch_and_add(&ip_id_counter, 1) & 0xFFFF);
-	pkt.ip.frag_off = 0;
-	pkt.ip.ttl = IP_DEFAULT_TTL;
-	pkt.ip.protocol = IPPROTO_UDP;
-	pkt.ip.saddr = this->server_ip;
-	pkt.ip.daddr = client_ip;
-	pkt.ip.check = 0;
-	pkt.ip.check = ip_checksum(&pkt.ip, sizeof(pkt.ip));
-
-	/* Build UDP header */
-	pkt.udp.source = htons(DHCP_SERVER_PORT);
-	pkt.udp.dest = htons(DHCP_CLIENT_PORT);
-	pkt.udp.len = htons(udp_len);
-	pkt.udp.check = 0;
-	pkt.udp.check = udp_checksum(pkt.ip.saddr, pkt.ip.daddr, &pkt.udp, udp_len);
-
-	/* Send via raw socket - routing handled by kernel policy */
 	memset(&dest, 0, sizeof(dest));
 	dest.sin_family = AF_INET;
+	dest.sin_port = htons(DHCP_CLIENT_PORT);
 	dest.sin_addr.s_addr = client_ip;
 
-	if (sendto(this->raw_fd, &pkt, total_len, 0,
+	if (sendto(this->fd, &ack, ack_len, 0,
 			   (struct sockaddr*)&dest, sizeof(dest)) < 0)
 	{
 		DBG1(DBG_NET, "dhcp-inform: failed to send DHCPACK: %s", strerror(errno));
@@ -654,55 +597,20 @@ static void send_dhcp_ack(private_dhcp_inform_responder_t *this,
 }
 
 /**
- * Process received DHCP packet
+ * Process a received DHCP message (UDP payload, IP/UDP headers already
+ * stripped by the kernel)
  */
 static void process_dhcp_packet(private_dhcp_inform_responder_t *this,
-								struct iphdr *ip, size_t len)
+								dhcp_packet_t *dhcp, size_t len)
 {
-	struct udphdr *udp;
-	dhcp_packet_t *dhcp;
-	size_t ip_hdr_len, udp_len;
-	uint8_t msg_type;
 	linked_list_t *routes;
+	identification_t *identity;
 	char client_ip_str[INET_ADDRSTRLEN];
 
-	if (len < sizeof(struct iphdr))
+	if (len < DHCP_MIN_MSG_SIZE)
 	{
 		return;
 	}
-
-	/* Validate IP header length field (ihl is in 32-bit words, valid range 5-15) */
-	if (ip->ihl < 5 || ip->ihl > 15)
-	{
-		return;
-	}
-
-	ip_hdr_len = ip->ihl * 4;
-	if (len < ip_hdr_len + sizeof(struct udphdr))
-	{
-		return;
-	}
-
-	udp = (struct udphdr*)((uint8_t*)ip + ip_hdr_len);
-	udp_len = ntohs(udp->len);
-
-	if (ntohs(udp->dest) != DHCP_SERVER_PORT)
-	{
-		return;
-	}
-
-	if (udp_len < sizeof(struct udphdr) + DHCP_MIN_MSG_SIZE)
-	{
-		return;
-	}
-
-	/* Verify actual buffer has enough data for DHCP packet before accessing */
-	if (len < ip_hdr_len + sizeof(struct udphdr) + sizeof(dhcp_packet_t))
-	{
-		return;
-	}
-
-	dhcp = (dhcp_packet_t*)((uint8_t*)udp + sizeof(struct udphdr));
 
 	/* Verify magic cookie */
 	if (ntohl(dhcp->magic) != DHCP_MAGIC_COOKIE)
@@ -716,9 +624,8 @@ static void process_dhcp_packet(private_dhcp_inform_responder_t *this,
 		return;
 	}
 
-	/* Only DHCPINFORM */
-	msg_type = get_dhcp_type(dhcp);
-	if (msg_type != DHCPINFORM)
+	/* Only DHCPINFORM, which carries the client's address in ciaddr */
+	if (get_dhcp_type(dhcp, len) != DHCPINFORM || !dhcp->ciaddr)
 	{
 		return;
 	}
@@ -727,19 +634,34 @@ static void process_dhcp_packet(private_dhcp_inform_responder_t *this,
 	inet_ntop(AF_INET, &dhcp->ciaddr, client_ip_str, sizeof(client_ip_str));
 	DBG1(DBG_NET, "dhcp-inform: received DHCPINFORM from %s", client_ip_str);
 
+	/* Identify the peer holding this virtual IP, if any */
+	identity = find_identity_by_vip(dhcp->ciaddr);
+	if (identity)
+	{
+		DBG1(DBG_NET, "dhcp-inform: client %s identified as %Y",
+			 client_ip_str, identity);
+	}
+	else
+	{
+		DBG2(DBG_NET, "dhcp-inform: no IKE_SA found for client %s",
+			 client_ip_str);
+	}
+
 	/* Get routes from providers (mutually exclusive: TS OR DB OR static) */
-	routes = get_routes_for_client(this, client_ip_str);
+	routes = get_routes_for_client(this, client_ip_str, identity);
 
 	if (!routes)
 	{
 		DBG1(DBG_NET, "dhcp-inform: CRITICAL - failed to get routes list for %s",
 			 client_ip_str);
+		DESTROY_IF(identity);
 		return;
 	}
 
 	if (routes->get_count(routes) > 0)
 	{
-		DBG1(DBG_NET, "dhcp-inform: sending DHCPACK with %d routes", routes->get_count(routes));
+		DBG1(DBG_NET, "dhcp-inform: sending DHCPACK with %d routes",
+			 routes->get_count(routes));
 		send_dhcp_ack(this, dhcp, routes, dhcp->ciaddr);
 	}
 	else
@@ -748,22 +670,23 @@ static void process_dhcp_packet(private_dhcp_inform_responder_t *this,
 	}
 
 	routes->destroy_offset(routes, offsetof(traffic_selector_t, destroy));
+	DESTROY_IF(identity);
 }
 
 /**
- * Watcher callback for packet socket
+ * Watcher callback for the DHCP socket
  */
 CALLBACK(receive_dhcp, bool,
 	private_dhcp_inform_responder_t *this, int fd, watcher_event_t event)
 {
-	uint8_t buf[2048 + sizeof(struct iphdr)];
-	struct iphdr *hdr = (struct iphdr*)buf;
+	dhcp_packet_t packet;
 	ssize_t len;
-	struct sockaddr_ll addr;
-	socklen_t alen = sizeof(addr);
 
-	len = recvfrom(fd, buf, sizeof(buf), MSG_DONTWAIT,
-				   (struct sockaddr*)&addr, &alen);
+	/* Zero so option parsing never walks uninitialized tail bytes when the
+	 * client sends less than the full options capacity */
+	memset(&packet, 0, sizeof(packet));
+
+	len = recvfrom(fd, &packet, sizeof(packet), MSG_DONTWAIT, NULL, NULL);
 
 	if (len < 0)
 	{
@@ -774,89 +697,78 @@ CALLBACK(receive_dhcp, bool,
 		return TRUE;
 	}
 
-	if (len >= (ssize_t)sizeof(struct iphdr))
-	{
-		process_dhcp_packet(this, hdr, len);
-	}
+	process_dhcp_packet(this, &packet, len);
 
 	return TRUE;
 }
 
 /**
- * Install BPF filter for DHCP broadcast packets
+ * Create the UDP socket receiving DHCPINFORM and sending replies
  */
-static bool install_filter(private_dhcp_inform_responder_t *this)
+static int create_dhcp_socket(const char *iface)
 {
-	/* BPF filter:
-	 * - IP protocol = UDP
-	 * - UDP dest port = 67 (DHCP server)
-	 * - Dest IP = broadcast (0xFFFFFFFF) or our subnet broadcast
-	 */
-	struct sock_filter filter_code[] = {
-		/* Load IP protocol */
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, offsetof(struct iphdr, protocol)),
-		/* Check if UDP (17) */
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_UDP, 0, 7),
-		/* Load IP header length */
-		BPF_STMT(BPF_LDX+BPF_B+BPF_MSH, 0),
-		/* Load UDP dest port (at IP header + 2) */
-		BPF_STMT(BPF_LD+BPF_H+BPF_IND, 2),
-		/* Check if port 67 */
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, DHCP_SERVER_PORT, 0, 4),
-		/* Load dest IP */
-		BPF_STMT(BPF_LD+BPF_W+BPF_ABS, offsetof(struct iphdr, daddr)),
-		/* Check if broadcast 255.255.255.255 */
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0xFFFFFFFF, 1, 0),
-		/* Also accept limited broadcast - reject */
-		BPF_STMT(BPF_RET+BPF_K, 0),
-		/* Accept packet */
-		BPF_STMT(BPF_LD+BPF_W+BPF_LEN, 0),
-		BPF_STMT(BPF_RET+BPF_A, 0),
+	struct sockaddr_in addr = {
+		.sin_family = AF_INET,
+		.sin_port = htons(DHCP_SERVER_PORT),
+		.sin_addr.s_addr = htonl(INADDR_ANY),
 	};
-	struct sock_fprog filter = {
-		.len = sizeof(filter_code) / sizeof(struct sock_filter),
-		.filter = filter_code,
-	};
+	int fd, on = 1;
 
-	if (setsockopt(this->pkt_fd, SOL_SOCKET, SO_ATTACH_FILTER,
-				   &filter, sizeof(filter)) < 0)
+	fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
+	if (fd < 0)
 	{
-		DBG1(DBG_NET, "dhcp-inform: failed to attach BPF filter: %s",
+		DBG1(DBG_NET, "dhcp-inform: failed to create socket: %s",
 			 strerror(errno));
-		return FALSE;
+		return -1;
 	}
 
-	return TRUE;
-}
-
-/**
- * Get interface index
- */
-static int get_ifindex(int fd, const char *ifname)
-{
-	struct ifreq ifr = {};
-
-	strncpy(ifr.ifr_name, ifname, IFNAMSIZ-1);
-	ifr.ifr_name[IFNAMSIZ-1] = '\0';
-
-	if (ioctl(fd, SIOCGIFINDEX, &ifr) == 0)
+	/* Coexist with a DHCP daemon serving the physical segment */
+	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0)
 	{
-		return ifr.ifr_ifindex;
+		DBG1(DBG_NET, "dhcp-inform: failed to set SO_REUSEADDR: %s",
+			 strerror(errno));
+		close(fd);
+		return -1;
 	}
-	return 0;
+
+	/* DHCPINFORM is typically sent to 255.255.255.255 */
+	if (setsockopt(fd, SOL_SOCKET, SO_BROADCAST, &on, sizeof(on)) < 0)
+	{
+		DBG1(DBG_NET, "dhcp-inform: failed to set SO_BROADCAST: %s",
+			 strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	/* Optional: restrict to the VPN interface. Tunnelled packets are still
+	 * delivered, they surface on the interface carrying the ESP traffic. */
+	if (iface && setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, iface,
+							strlen(iface)) < 0)
+	{
+		DBG1(DBG_NET, "dhcp-inform: failed to bind to %s: %s",
+			 iface, strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
+	{
+		DBG1(DBG_NET, "dhcp-inform: failed to bind to port 67: %s",
+			 strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	return fd;
 }
 
 METHOD(dhcp_inform_responder_t, destroy, void,
 	private_dhcp_inform_responder_t *this)
 {
-	if (this->pkt_fd >= 0)
+	if (this->fd >= 0)
 	{
-		lib->watcher->remove(lib->watcher, this->pkt_fd);
-		close(this->pkt_fd);
-	}
-	if (this->raw_fd >= 0)
-	{
-		close(this->raw_fd);
+		lib->watcher->remove(lib->watcher, this->fd);
+		close(this->fd);
 	}
 
 	/* Destroy providers */
@@ -884,15 +796,13 @@ dhcp_inform_responder_t *dhcp_inform_responder_create()
 {
 	private_dhcp_inform_responder_t *this;
 	char *iface, *server_ip, *dns_server;
-	int on = 1;
 	bool has_routes = FALSE;
 
 	INIT(this,
 		.public = {
 			.destroy = _destroy,
 		},
-		.pkt_fd = -1,
-		.raw_fd = -1,
+		.fd = -1,
 	);
 
 	/* Get configuration */
@@ -972,73 +882,20 @@ dhcp_inform_responder_t *dhcp_inform_responder_create()
 		}
 	}
 
-	/* Create packet socket for receiving broadcasts */
-	this->pkt_fd = socket(AF_PACKET, SOCK_DGRAM, htons(ETH_P_IP));
-	if (this->pkt_fd < 0)
-	{
-		DBG1(DBG_NET, "dhcp-inform: failed to create packet socket: %s",
-			 strerror(errno));
-		destroy(this);
-		return NULL;
-	}
-
-	/* Create raw socket for sending responses */
-	this->raw_fd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW);
-	if (this->raw_fd < 0)
-	{
-		DBG1(DBG_NET, "dhcp-inform: failed to create raw socket: %s",
-			 strerror(errno));
-		destroy(this);
-		return NULL;
-	}
-
-	/* Set IP_HDRINCL for raw socket */
-	if (setsockopt(this->raw_fd, IPPROTO_IP, IP_HDRINCL, &on, sizeof(on)) < 0)
-	{
-		DBG1(DBG_NET, "dhcp-inform: failed to set IP_HDRINCL: %s",
-			 strerror(errno));
-		destroy(this);
-		return NULL;
-	}
-
-	/* Get interface index and bind packet socket */
-	if (iface)
-	{
-		this->ifindex = get_ifindex(this->raw_fd, iface);
-		if (!this->ifindex)
-		{
-			DBG1(DBG_NET, "dhcp-inform: failed to get interface index for %s",
-				 iface);
-			destroy(this);
-			return NULL;
-		}
-
-		struct sockaddr_ll addr = {
-			.sll_family = AF_PACKET,
-			.sll_protocol = htons(ETH_P_IP),
-			.sll_ifindex = this->ifindex,
-		};
-		if (bind(this->pkt_fd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
-		{
-			DBG1(DBG_NET, "dhcp-inform: failed to bind packet socket to %s: %s",
-				 iface, strerror(errno));
-			destroy(this);
-			return NULL;
-		}
-	}
-
-	/* Install BPF filter */
-	if (!install_filter(this))
+	/* Create the UDP socket used for both directions */
+	this->fd = create_dhcp_socket(iface);
+	if (this->fd < 0)
 	{
 		destroy(this);
 		return NULL;
 	}
 
 	/* Register with watcher */
-	lib->watcher->add(lib->watcher, this->pkt_fd, WATCHER_READ,
+	lib->watcher->add(lib->watcher, this->fd, WATCHER_READ,
 					  receive_dhcp, this);
 
-	DBG1(DBG_NET, "dhcp-inform: responder started on %s", iface ?: "all");
+	DBG1(DBG_NET, "dhcp-inform: responder started on %s (%s)",
+		 iface ?: "all", server_ip);
 
 	return &this->public;
 }

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_responder.c
@@ -816,19 +816,12 @@ static int create_dhcp_socket(const char *iface)
 		return -errno;
 	}
 
-	/* The port is owned exclusively: SO_REUSEPORT would make the kernel
-	 * load-balance unicast port-67 flows across the reuse group, silently
-	 * stealing renewals from a co-located DHCP daemon. If another daemon
-	 * owns the port, bind fails and the responder starts disabled instead.
-	 * SO_REUSEADDR just keeps rebinding painless after restarts. */
-	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0)
-	{
-		DBG1(DBG_NET, "dhcp-inform: failed to set SO_REUSEADDR: %s",
-			 strerror(errno));
-		err = errno;
-		close(fd);
-		return -err;
-	}
+	/* The port is owned exclusively, without any address reuse: for UDP,
+	 * SO_REUSEADDR/SO_REUSEPORT would let this bind slip next to an
+	 * existing DHCP daemon and divert its unicast traffic. UDP has no
+	 * TIME_WAIT, so nothing is needed for restart handling either; when
+	 * another daemon owns the port, bind fails with EADDRINUSE and the
+	 * responder starts disabled. */
 
 	/* DHCPINFORM is typically sent to 255.255.255.255 */
 	if (setsockopt(fd, SOL_SOCKET, SO_BROADCAST, &on, sizeof(on)) < 0)
@@ -1004,6 +997,13 @@ dhcp_inform_responder_t *dhcp_inform_responder_create()
 	/* Register with watcher */
 	lib->watcher->add(lib->watcher, this->fd, WATCHER_READ,
 					  receive_dhcp, this);
+
+	/* Warm the FQDN cache only now: construction cannot fail anymore, so
+	 * the queued background jobs cannot outlive the provider they use */
+	if (this->db_provider)
+	{
+		this->db_provider->prewarm(this->db_provider);
+	}
 
 	DBG1(DBG_NET, "dhcp-inform: responder started on %s (%s)",
 		 iface ?: "all", server_ip);

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
@@ -393,7 +393,8 @@ static linked_list_t *clone_routes(linked_list_t *source)
 }
 
 METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
-	private_dhcp_inform_static_provider_t *this, const char *client_ip)
+	private_dhcp_inform_static_provider_t *this, const char *client_ip,
+	identification_t *identity)
 {
 	enumerator_t *enumerator;
 	pool_entry_t *pool;

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_static_provider.c
@@ -133,8 +133,8 @@ static traffic_selector_t *parse_cidr(const char *cidr)
 		return NULL;
 	}
 
+	/* the constructor adopts and destroys the host */
 	ts = traffic_selector_create_from_subnet(host, prefix, 0, 0, 65535);
-	host->destroy(host);
 	free(ip_str);
 
 	return ts;

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
@@ -202,7 +202,8 @@ static linked_list_t *extract_ts_from_ike_sa(const char *client_ip)
 }
 
 METHOD(dhcp_inform_provider_t, get_routes, linked_list_t*,
-	private_dhcp_inform_ts_provider_t *this, const char *client_ip)
+	private_dhcp_inform_ts_provider_t *this, const char *client_ip,
+	identification_t *identity)
 {
 	linked_list_t *routes;
 

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
@@ -157,9 +157,10 @@ static linked_list_t *extract_ts_from_ike_sa(const char *client_ip)
 		child_enum = ike_sa->create_child_sa_enumerator(ike_sa);
 		while (child_enum->enumerate(child_enum, &child_sa))
 		{
-			/* Get remote (server-side) traffic selectors - these are the
-			 * networks the client should be able to reach */
-			ts_enum = child_sa->create_ts_enumerator(child_sa, FALSE);
+			/* The gateway's local (own) traffic selectors are the protected
+			 * networks the client reaches through the tunnel; the remote
+			 * side would merely name the client's own virtual IP */
+			ts_enum = child_sa->create_ts_enumerator(child_sa, TRUE);
 			while (ts_enum->enumerate(ts_enum, &ts))
 			{
 				traffic_selector_t *clone;

--- a/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
+++ b/src/libcharon/plugins/dhcp_inform/dhcp_inform_ts_provider.c
@@ -123,9 +123,13 @@ static linked_list_t *extract_ts_from_ike_sa(const char *client_ip)
 		return routes;
 	}
 
-	/* Enumerate all IKE SAs to find one matching this client */
+	/* Enumerate all IKE SAs to find one matching this client.
+	 * wait = FALSE: the manager's wait for a checked-out SA is unbounded,
+	 * so waiting would let one stuck SA anywhere stall all DHCP service.
+	 * Skipping a busy SA at worst costs this exchange its routes and the
+	 * client's next INFORM refreshes them. */
 	ike_enum = charon->ike_sa_manager->create_enumerator(
-										charon->ike_sa_manager, TRUE);
+										charon->ike_sa_manager, FALSE);
 
 	while (ike_enum->enumerate(ike_enum, &ike_sa))
 	{


### PR DESCRIPTION
## Summary

The packaged plugin never received the client's DHCPINFORM (#40): the responder used an AF_PACKET socket with a BPF filter, and road-warrior DHCPINFORM arrives as xfrm-decapsulated tunnel payload that a device-level packet socket never delivers. tcpdump saw the packet, the plugin saw nothing.

The plugin's original deployment solved exactly this in its final iteration with a plain UDP socket; those sources were lost, the fork imported an earlier snapshot, and the per-identity route lookup carried by that snapshot was later dropped as dead code because the snapshot had not wired it up yet. This PR restores both, keeping the provider architecture.

## Changes

- dhcp_inform_responder.c: single UDP socket bound to port 67 (SO_REUSEADDR, SO_BROADCAST, optional SO_BINDTODEVICE for `interface=`) replaces the AF_PACKET+BPF receive socket and the raw IP send socket. Receive via watcher, DHCPACK via sendto to ciaddr:68; the hand-rolled IP/UDP headers and checksums are gone. 300-byte BOOTP-minimum messages are now accepted (the old path demanded the full options capacity, rejecting every real Windows INFORM even on the wire) and option parsing is bounded by the received length
- Identity lookup: the client's IKE_SA is found by its virtual IP, its identity is logged and passed to route providers
- dhcp_inform_db_provider.c: consults v_user_routes (identity, resource_type ip|cidr|fqdn, resource_value; identity matched without the domain part) next to the existing v_pool_routes, results merged and deduplicated; either view may be absent. FQDN resources resolve at request time
- Double-free fix (separate commit): traffic_selector_create_from_subnet() adopts the passed host, the explicit host->destroy() after it in both parse_cidr() helpers aborted charon with 'double free detected in tcache' on the first answered request, previously unreachable because no request ever arrived
- dhcp-inform.conf: documents both database views

- Hardening from the review rounds: non-IPv4 resources and selectors are excluded end to end (options 121/249 are IPv4-only), the identity lookup key uses the printable identity of get_other_eap_id() with domain stripping limited to mail-style identities, the DHCPACK source is pinned to the server address via IP_PKTINFO with a routed-source fallback, FQDN resolutions are cached for five minutes, IKE_SA enumeration does not wait on checked-out SAs, truncated DHCP options are rejected, the plugin keeps CAP_NET_BIND_SERVICE (not CAP_NET_RAW), and a foreign daemon owning port 67 without SO_REUSEPORT leaves charon running with the responder disabled instead of failing startup

## Testing

Full-stack in a clean ubuntu:24.04 container (charon + sqlite routes, NET_ADMIN):

- crafted 300-byte DHCPINFORM (ciaddr set, option 55 requesting 249) sent to :67
- charon logs received DHCPINFORM -> identity lookup (no IKE_SA in container, degrades to pool routes) -> found 1 route -> sent DHCPACK
- the DHCPACK arrives on :68 with xid/ciaddr echoed and options 121 and 249 both carrying 10.48.4.220/32 via 10.0.0.1
- plugin builds cleanly with -Werror; the v_user_routes identity path needs a live IKE_SA and was validated for graceful degradation only

Closes #41
Part of #40
